### PR TITLE
Add audio modality support to response helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ print(ratings)
 
 Each task returns a `pandas.DataFrame` and saves raw responses to disk.  Set `use_dummy=False` and provide your OpenAI credentials via the `OPENAI_API_KEY` environment variable to perform real API calls.
 
-### Image inputs
+### Image and audio inputs
 
-`get_response` and `get_all_responses` can optionally include images with your prompts. Pass the `images` parameter to `get_response` or a mapping `prompt_images` to `get_all_responses`, where each key is a prompt identifier and the value is a list of base64 strings. A helper `encode_image` is provided:
+`get_response` and `get_all_responses` can optionally include images or audio with your prompts. Pass the `images` and/or `audio` parameters to `get_response` or mappings `prompt_images` and `prompt_audio` to `get_all_responses`, where each key is a prompt identifier and the value is a list preserving the order of the supplied media. Images should be base64 strings and audio entries should be dictionaries containing `data` and `format`. A helper `encode_image` is provided:
 
 ```python
 from gabriel.utils import encode_image

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -50,6 +50,15 @@ def test_get_response_images_dummy():
     assert responses and responses[0].startswith("DUMMY")
 
 
+def test_get_response_audio_dummy():
+    responses, _ = asyncio.run(
+        openai_utils.get_response(
+            "hi", audio=[{"data": "abcd", "format": "mp3"}], use_dummy=True
+        )
+    )
+    assert responses and responses[0].startswith("DUMMY")
+
+
 def test_gpt5_temperature_warning(caplog):
     """Ensure gpt-5 models ignore temperature and log a warning."""
     with caplog.at_level("WARNING"):
@@ -90,6 +99,19 @@ def test_get_all_responses_images_dummy(tmp_path):
             identifiers=["1"],
             prompt_images={"1": ["abcd"]},
             save_path=str(tmp_path / "img.csv"),
+            use_dummy=True,
+        )
+    )
+    assert len(df) == 1
+
+
+def test_get_all_responses_audio_dummy(tmp_path):
+    df = asyncio.run(
+        openai_utils.get_all_responses(
+            prompts=["a"],
+            identifiers=["1"],
+            prompt_audio={"1": [{"data": "abcd", "format": "mp3"}]},
+            save_path=str(tmp_path / "aud.csv"),
             use_dummy=True,
         )
     )


### PR DESCRIPTION
## Summary
- allow audio inputs in `get_response` via chat completions when provided
- accept `prompt_audio` in `get_all_responses` and forward audio to `get_response`
- document and test image/audio input handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b4c60ad40832e9b4eaa40d87afce0