### PR TITLE
Add modality-aware prompts and media support

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -30,6 +30,9 @@ async def rate(
     reset_files: bool = False,
     use_dummy: bool = False,
     file_name: str = "ratings.csv",
+    modality: str = "text",
+    image_column: Optional[str] = None,
+    audio_column: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rate`."""
@@ -43,9 +46,16 @@ async def rate(
         n_runs=n_runs,
         use_dummy=use_dummy,
         additional_instructions=additional_instructions,
+        modality=modality,
         **cfg_kwargs,
     )
-    return await Rate(cfg).run(df, column_name, reset_files=reset_files)
+    return await Rate(cfg).run(
+        df,
+        column_name,
+        reset_files=reset_files,
+        image_column=image_column,
+        audio_column=audio_column,
+    )
 
 async def classify(
     df: pd.DataFrame,
@@ -61,6 +71,9 @@ async def classify(
     reset_files: bool = False,
     use_dummy: bool = False,
     file_name: str = "classify_responses.csv",
+    modality: str = "text",
+    image_column: Optional[str] = None,
+    audio_column: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Classify`."""
@@ -75,9 +88,16 @@ async def classify(
         min_frequency=min_frequency,
         additional_instructions=additional_instructions or "",
         use_dummy=use_dummy,
+        modality=modality,
         **cfg_kwargs,
     )
-    return await Classify(cfg).run(df, column_name, reset_files=reset_files)
+    return await Classify(cfg).run(
+        df,
+        column_name,
+        reset_files=reset_files,
+        image_column=image_column,
+        audio_column=audio_column,
+    )
 
 
 async def deidentify(
@@ -129,6 +149,9 @@ async def rank(
     use_dummy: bool = False,
     file_name: str = "rankings",
     reset_files: bool = False,
+    modality: str = "text",
+    image_column: Optional[str] = None,
+    audio_column: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rank`."""
@@ -147,9 +170,16 @@ async def rank(
         save_dir=save_dir,
         file_name=file_name,
         additional_instructions=additional_instructions or "",
+        modality=modality,
         **cfg_kwargs,
     )
-    return await Rank(cfg).run(df, column_name, reset_files=reset_files)
+    return await Rank(cfg).run(
+        df,
+        column_name,
+        reset_files=reset_files,
+        image_column=image_column,
+        audio_column=audio_column,
+    )
 
 
 async def codify(

--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -34,6 +34,7 @@ class ClassifyConfig:
     additional_guidelines: str = ""
     use_dummy: bool = False
     timeout: float = 60.0
+    modality: str = "text"
 
 
 # ────────────────────────────
@@ -82,6 +83,7 @@ class Classify:
                     labels=self.cfg.labels,
                     additional_instructions=self.cfg.additional_instructions,
                     additional_guidelines=self.cfg.additional_guidelines,
+                    modality=self.cfg.modality,
                 )
             )
             ids.append(sha8)
@@ -140,6 +142,8 @@ class Classify:
         text_column: str,
         *,
         reset_files: bool = False,
+        image_column: Optional[str] = None,
+        audio_column: Optional[str] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Classify texts in ``df[text_column]`` and return ``df`` with label columns."""
@@ -148,6 +152,24 @@ class Classify:
         texts = df_proc[text_column].astype(str).tolist()
 
         prompts, ids, id_to_rows, id_to_text = self._build(texts)
+
+        prompt_images: Optional[Dict[str, List[str]]] = None
+        if image_column is not None and image_column in df_proc:
+            prompt_images = {}
+            img_list = df_proc[image_column].tolist()
+            for ident, rows in id_to_rows.items():
+                imgs = img_list[rows[0]]
+                if imgs:
+                    prompt_images[ident] = imgs
+
+        prompt_audio: Optional[Dict[str, List[Dict[str, str]]]] = None
+        if audio_column is not None and audio_column in df_proc:
+            prompt_audio = {}
+            aud_list = df_proc[audio_column].tolist()
+            for ident, rows in id_to_rows.items():
+                auds = aud_list[rows[0]]
+                if auds:
+                    prompt_audio[ident] = auds
 
         base_name = os.path.splitext(self.cfg.file_name)[0]
         csv_path = os.path.join(self.cfg.save_dir, f"{base_name}_raw_responses.csv")
@@ -159,6 +181,8 @@ class Classify:
             df_resp_all = await get_all_responses(
                 prompts=prompts,
                 identifiers=ids,
+                prompt_images=prompt_images,
+                prompt_audio=prompt_audio,
                 n_parallels=self.cfg.n_parallels,
                 save_path=csv_path,
                 reset_files=reset_files,
@@ -179,9 +203,24 @@ class Classify:
                 prompts_all.extend(prompts)
                 ids_all.extend([f"{ident}_run{run_idx}" for ident in ids])
 
+            prompt_images_all: Optional[Dict[str, List[str]]] = None
+            if prompt_images:
+                prompt_images_all = {}
+                for ident, imgs in prompt_images.items():
+                    for run_idx in range(1, self.cfg.n_runs + 1):
+                        prompt_images_all[f"{ident}_run{run_idx}"] = imgs
+            prompt_audio_all: Optional[Dict[str, List[Dict[str, str]]]] = None
+            if prompt_audio:
+                prompt_audio_all = {}
+                for ident, auds in prompt_audio.items():
+                    for run_idx in range(1, self.cfg.n_runs + 1):
+                        prompt_audio_all[f"{ident}_run{run_idx}"] = auds
+
             df_resp_all = await get_all_responses(
                 prompts=prompts_all,
                 identifiers=ids_all,
+                prompt_images=prompt_images_all,
+                prompt_audio=prompt_audio_all,
                 n_parallels=self.cfg.n_parallels,
                 save_path=csv_path,
                 reset_files=reset_files,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,7 +22,7 @@ def test_prompt_template():
 def test_ratings_default_scale_prompt():
     tmpl = PromptTemplate.from_package("ratings_prompt.jinja2")
     rendered = tmpl.render(text="x", attributes=["clarity"], scale=None)
-    assert "All ratings are on a scale" in rendered
+    assert "Use integers 0-100" in rendered
 
 
 def test_shuffled_dict_rendering():


### PR DESCRIPTION
## Summary
- Add `modality` to API wrappers and task configs so prompts adapt to text, image, audio, entity, or web inputs
- Support optional image and audio columns in Rate, Classify, Rank, and Elo tasks, piping media into `get_all_responses`
- Update ranking prompts to use `entry_circle`/`entry_square` variables when rendering comparisons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b6d8f474c832eae99260923ea365a