### PR TITLE
Ensure modality propagates to web search

### DIFF
--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -174,6 +174,8 @@ class Classify:
         base_name = os.path.splitext(self.cfg.file_name)[0]
         csv_path = os.path.join(self.cfg.save_dir, f"{base_name}_raw_responses.csv")
 
+        kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+
         if not isinstance(self.cfg.n_runs, int) or self.cfg.n_runs < 1:
             raise ValueError("n_runs must be an integer >= 1")
 

--- a/src/gabriel/tasks/rank.py
+++ b/src/gabriel/tasks/rank.py
@@ -640,6 +640,8 @@ class Rank:
         # prepare file paths
         base_name = os.path.splitext(self.cfg.file_name)[0]
         final_path = os.path.join(self.cfg.save_dir, f"{base_name}_final.csv")
+
+        kwargs.setdefault("use_web_search", self.cfg.modality == "web")
         # Determine how many rounds have already been processed when
         # `reset_files` is False.  We look for files named
         # ``<base_name>_round<k>.csv`` to infer progress.  If a final

--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -131,6 +131,8 @@ class Rate:
         base_name = os.path.splitext(self.cfg.file_name)[0]
         csv_path = os.path.join(self.cfg.save_dir, f"{base_name}_raw_responses.csv")
 
+        kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+
         if not isinstance(self.cfg.n_runs, int) or self.cfg.n_runs < 1:
             raise ValueError("n_runs must be an integer >= 1")
 


### PR DESCRIPTION
## Summary
- Honor `modality='web'` in Rate, Classify and Rank tasks by enabling `use_web_search`
- Allows API modality parameter to reach prompt calls for text, entity, web, image and audio

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bacf46bf0832ebb990dc496969677