### PR TITLE
Support file paths for media inputs

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -31,8 +31,6 @@ async def rate(
     use_dummy: bool = False,
     file_name: str = "ratings.csv",
     modality: str = "text",
-    image_column: Optional[str] = None,
-    audio_column: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rate`."""
@@ -53,8 +51,6 @@ async def rate(
         df,
         column_name,
         reset_files=reset_files,
-        image_column=image_column,
-        audio_column=audio_column,
     )
 
 async def classify(
@@ -72,8 +68,6 @@ async def classify(
     use_dummy: bool = False,
     file_name: str = "classify_responses.csv",
     modality: str = "text",
-    image_column: Optional[str] = None,
-    audio_column: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Classify`."""
@@ -95,8 +89,6 @@ async def classify(
         df,
         column_name,
         reset_files=reset_files,
-        image_column=image_column,
-        audio_column=audio_column,
     )
 
 
@@ -150,8 +142,6 @@ async def rank(
     file_name: str = "rankings",
     reset_files: bool = False,
     modality: str = "text",
-    image_column: Optional[str] = None,
-    audio_column: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rank`."""
@@ -177,8 +167,6 @@ async def rank(
         df,
         column_name,
         reset_files=reset_files,
-        image_column=image_column,
-        audio_column=audio_column,
     )
 
 

--- a/src/gabriel/utils/__init__.py
+++ b/src/gabriel/utils/__init__.py
@@ -2,9 +2,10 @@
 
 from .openai_utils import get_response, get_all_responses
 from .image_utils import encode_image
+from .audio_utils import encode_audio
 from .logging import get_logger, set_log_level
 from .teleprompter import Teleprompter
-from .mapmaker import MapMaker
+from .mapmaker import MapMaker, create_county_choropleth
 from .prompt_paraphraser import PromptParaphraser, PromptParaphraserConfig
 from .parsing import safe_json, safest_json, clean_json_df
 from .jinja import shuffled, shuffled_dict, get_env
@@ -23,12 +24,14 @@ __all__ = [
     "set_log_level",
     "Teleprompter",
     "MapMaker",
+    "create_county_choropleth",
     "PromptParaphraser",
     "PromptParaphraserConfig",
     "safe_json",
     "safest_json",
     "clean_json_df",
     "encode_image",
+    "encode_audio",
     "shuffled",
     "shuffled_dict",
     "get_env",

--- a/src/gabriel/utils/audio_utils.py
+++ b/src/gabriel/utils/audio_utils.py
@@ -1,0 +1,42 @@
+"""Utility helpers for working with audio files."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Dict, Optional
+
+
+def encode_audio(audio_path: str) -> Optional[Dict[str, str]]:
+    """Return the audio at ``audio_path`` as a dict suitable for the OpenAI API.
+
+    The returned dictionary has two keys:
+
+    ``data``
+        Base64 encoded contents of the file.
+
+    ``format``
+        The lowercase file extension (e.g. ``"mp3"``, ``"wav"``).  If the
+        extension cannot be determined ``"wav"`` is used as a fallback.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to the audio file to encode.
+
+    Returns
+    -------
+    dict or None
+        A mapping with ``data`` and ``format`` keys, or ``None`` if reading the
+        file fails.
+    """
+
+    try:
+        path = Path(audio_path)
+        with path.open("rb") as f:
+            b64 = base64.b64encode(f.read()).decode("utf-8")
+        ext = path.suffix.lstrip(".").lower() or "wav"
+        return {"data": b64, "format": ext}
+    except Exception:
+        return None
+

--- a/src/gabriel/utils/mapmaker.py
+++ b/src/gabriel/utils/mapmaker.py
@@ -285,3 +285,23 @@ class MapMaker:
             else:
                 # should not happen due to validation in __init__
                 raise ValueError(f"Unsupported map type: {self.map_type}")
+
+
+def create_county_choropleth(
+    df: pd.DataFrame,
+    *,
+    fips_col: str,
+    value_col: str,
+    title: str,
+    save_path: str,
+    z_score: bool = True,
+) -> None:
+    """Backward compatible helper to generate a county-level choropleth.
+
+    This thin wrapper instantiates :class:`MapMaker` and delegates to its
+    internal implementation.  It mirrors the signature of the legacy
+    ``create_county_choropleth`` function used elsewhere in the codebase.
+    """
+
+    mm = MapMaker(df, fips_col=fips_col, z_score=z_score, save_dir=None, map_type="county")
+    mm._create_county_choropleth(df, fips_col, value_col, title, save_path)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -122,7 +122,7 @@ def test_ratings_dummy(tmp_path):
     cfg = RateConfig(attributes={"helpfulness": ""}, save_dir=str(tmp_path), file_name="ratings.csv", use_dummy=True)
     task = Rate(cfg)
     data = pd.DataFrame({"text": ["hello"]})
-    df = asyncio.run(task.run(data, text_column="text"))
+    df = asyncio.run(task.run(data, column_name="text"))
     assert not df.empty
     assert "helpfulness" in df.columns
 
@@ -131,7 +131,7 @@ def test_ratings_multirun(tmp_path):
     cfg = RateConfig(attributes={"helpfulness": ""}, save_dir=str(tmp_path), file_name="ratings.csv", use_dummy=True, n_runs=2)
     task = Rate(cfg)
     data = pd.DataFrame({"text": ["hello"]})
-    df = asyncio.run(task.run(data, text_column="text"))
+    df = asyncio.run(task.run(data, column_name="text"))
     assert "helpfulness" in df.columns
     disagg = pd.read_csv(tmp_path / "ratings_full_disaggregated.csv", index_col=[0, 1])
     assert set(disagg.index.names) == {"text", "run"}
@@ -149,7 +149,7 @@ def test_classification_dummy(tmp_path):
     cfg = ClassifyConfig(labels={"yes": ""}, save_dir=str(tmp_path), use_dummy=True)
     task = Classify(cfg)
     df = pd.DataFrame({"txt": ["a", "b"]})
-    res = asyncio.run(task.run(df, text_column="txt"))
+    res = asyncio.run(task.run(df, column_name="txt"))
     assert "yes" in res.columns
 
 
@@ -157,7 +157,7 @@ def test_classification_multirun(tmp_path):
     cfg = ClassifyConfig(labels={"yes": ""}, save_dir=str(tmp_path), use_dummy=True, n_runs=2)
     task = Classify(cfg)
     df = pd.DataFrame({"txt": ["a"]})
-    res = asyncio.run(task.run(df, text_column="txt"))
+    res = asyncio.run(task.run(df, column_name="txt"))
     assert "yes" in res.columns
     disagg = pd.read_csv(tmp_path / "classify_responses_full_disaggregated.csv", index_col=[0, 1])
     assert set(disagg.index.names) == {"text", "run"}
@@ -196,7 +196,7 @@ def test_prompt_paraphraser_ratings(tmp_path):
     parap_cfg = PromptParaphraserConfig(n_variants=2, save_dir=str(tmp_path / "para"), use_dummy=True)
     paraphraser = PromptParaphraser(parap_cfg)
     data = pd.DataFrame({"txt": ["hello"]})
-    df = asyncio.run(paraphraser.run(Rate, cfg, data, text_column="txt"))
+    df = asyncio.run(paraphraser.run(Rate, cfg, data, column_name="txt"))
     assert set(df.prompt_variant) == {"baseline", "variant_1", "variant_2"}
 
 


### PR DESCRIPTION
## Summary
- simplify `rate`, `classify`, and `rank` to accept a single `column_name` holding either text or media paths
- base64-encode images or audio from that column when the modality requires it
- streamline API helpers and tests for the unified media-first interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bc1ca8d20832ea07b8f60978f3bb7