### PR TITLE
Fix reset_files behaviour in get_all_responses

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -977,6 +977,13 @@ async def get_all_responses(
         except Exception:
             # Ignore errors here; they will surface when attempting to write
             pass
+    if reset_files:
+        for p in (save_path, save_path + ".batch_state.json"):
+            try:
+                if os.path.exists(p):
+                    os.remove(p)
+            except Exception:
+                pass
     if os.path.exists(save_path) and not reset_files:
         df = pd.read_csv(save_path)
         df = df.drop_duplicates(subset=["Identifier"], keep="last")

--- a/tests/test_reset_files.py
+++ b/tests/test_reset_files.py
@@ -1,0 +1,24 @@
+import asyncio
+from gabriel.utils import openai_utils
+
+
+def test_get_all_responses_reset_files(tmp_path):
+    save_path = tmp_path / "out.csv"
+    asyncio.run(
+        openai_utils.get_all_responses(
+            prompts=["a", "b"],
+            identifiers=["1", "2"],
+            save_path=str(save_path),
+            use_dummy=True,
+        )
+    )
+    df = asyncio.run(
+        openai_utils.get_all_responses(
+            prompts=["b"],
+            identifiers=["2"],
+            save_path=str(save_path),
+            use_dummy=True,
+            reset_files=True,
+        )
+    )
+    assert set(df["Identifier"]) == {"2"}


### PR DESCRIPTION
## Summary
- Ensure `reset_files=True` deletes prior response files in `get_all_responses`
- Add regression test verifying reset removes stale identifiers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bde1c3a30832e8161c64e819f536b