### PR TITLE
Handle dict responses in classify parser

### DIFF
--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -79,12 +79,15 @@ class Classify:
             resp = resp[0]
         if isinstance(resp, (bytes, bytearray)):
             resp = resp.decode()
+        data: Optional[Any] = None
         if isinstance(resp, str):
             m = self._FENCE_RE.search(resp)
             if m:
                 resp = m.group(1).strip()
 
             data = await safest_json(resp)
+        elif isinstance(resp, dict):
+            data = resp
         if isinstance(data, dict):
             norm = {
                 k.strip().lower(): (

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -195,6 +195,13 @@ def test_classification_multirun(tmp_path):
     assert set(disagg.index.names) == {"text", "run"}
 
 
+def test_classify_parse_dict(tmp_path):
+    cfg = ClassifyConfig(labels={"yes": ""}, save_dir=str(tmp_path), use_dummy=True)
+    task = Classify(cfg)
+    parsed = asyncio.run(task._parse({"yes": True}, ["yes"]))
+    assert parsed["yes"] is True
+
+
 def test_regional_dummy(tmp_path):
     data = pd.DataFrame({"county": ["A", "B"]})
     cfg = RegionalConfig(save_dir=str(tmp_path), use_dummy=True)


### PR DESCRIPTION
## Summary
- prevent `UnboundLocalError` by initializing `data` and accepting pre-parsed dict responses in classification parsing
- add regression test for parsing dict responses without error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cbdd4505c832ea8ca9eb1934d0606