### PR TITLE
Enable JSON responses for audio inputs

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -751,6 +751,8 @@ async def get_response(
             "temperature": temperature,
             "modalities": ["text"],
         }
+        if json_mode:
+            params_chat["response_format"] = {"type": "json_object"}
         if tools is not None:
             params_chat["tools"] = tools
         if tool_choice is not None:


### PR DESCRIPTION
## Summary
- restore expected_schema plumbing in codify and OpenAI utilities
- ensure audio chat completions request JSON mode so outputs parse cleanly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689cc1926e6c832ea9578a4fc5c00187