### PR TITLE
Make summaries opt-in and reasoning optional

### DIFF
--- a/county_counter.py
+++ b/county_counter.py
@@ -25,7 +25,8 @@ class CountyCounter:
         run_name: Optional[str] = None,
         model_regional: str = "gpt-5-mini",
         model_elo: str = "gpt-5-mini",
-        reasoning_effort: str = "medium",
+        reasoning_effort: Optional[str] = None,
+        include_summaries: bool = False,
         search_context_size: str = "medium",
         n_parallels: int = 400,
         n_elo_rounds: int = 15,
@@ -48,6 +49,7 @@ class CountyCounter:
         self.additional_instructions = additional_instructions
         self.elo_instructions = elo_instructions
         self.reasoning_effort = reasoning_effort
+        self.include_summaries = include_summaries
         self.search_context_size = search_context_size
         self.z_score_choropleth = z_score_choropleth
         self.elo_attributes = elo_attributes
@@ -68,6 +70,7 @@ class CountyCounter:
             use_dummy=self.use_dummy,
             additional_instructions=self.additional_instructions,
             reasoning_effort=self.reasoning_effort,
+            include_summaries=self.include_summaries,
             search_context_size=self.search_context_size,
             print_example_prompt=True,
         )
@@ -96,6 +99,8 @@ class CountyCounter:
                 instructions=self.elo_instructions,
                 print_example_prompt=False,
                 timeout=self.elo_timeout,
+                reasoning_effort=self.reasoning_effort,
+                include_summaries=self.include_summaries,
             )
             rater = EloRater(cfg)
             elo_df = await rater.run(df_topic, text_col="text", id_col="identifier")

--- a/regional.py
+++ b/regional.py
@@ -24,7 +24,8 @@ class Regional:
         n_parallels: int = 400,
         use_dummy: bool = False,
         additional_instructions: str = "",
-        reasoning_effort: str = "medium",
+        reasoning_effort: Optional[str] = None,
+        include_summaries: bool = False,
         search_context_size: str = "medium",
         print_example_prompt: bool = True,
     ) -> None:
@@ -36,6 +37,7 @@ class Regional:
         self.use_dummy = use_dummy
         self.additional_instructions = additional_instructions
         self.reasoning_effort = reasoning_effort
+        self.include_summaries = include_summaries
         self.search_context_size = search_context_size
         self.print_example_prompt = print_example_prompt
 
@@ -72,6 +74,7 @@ class Regional:
             use_web_search=True,
             search_context_size=self.search_context_size,
             reasoning_effort=self.reasoning_effort,
+            include_summaries=self.include_summaries,
             save_path=csv_path,
             reset_files=reset_files,
             use_dummy=self.use_dummy,

--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -31,7 +31,8 @@ async def rate(
     use_dummy: bool = False,
     file_name: str = "ratings.csv",
     modality: str = "text",
-    reasoning_effort: str = "medium",
+    reasoning_effort: Optional[str] = None,
+    include_summaries: bool = False,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rate`."""
@@ -47,6 +48,7 @@ async def rate(
         additional_instructions=additional_instructions,
         modality=modality,
         reasoning_effort=reasoning_effort,
+        include_summaries=include_summaries,
         **cfg_kwargs,
     )
     return await Rate(cfg).run(
@@ -70,7 +72,8 @@ async def classify(
     use_dummy: bool = False,
     file_name: str = "classify_responses.csv",
     modality: str = "text",
-    reasoning_effort: str = "medium",
+    reasoning_effort: Optional[str] = None,
+    include_summaries: bool = False,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Classify`."""
@@ -87,6 +90,7 @@ async def classify(
         use_dummy=use_dummy,
         modality=modality,
         reasoning_effort=reasoning_effort,
+        include_summaries=include_summaries,
         **cfg_kwargs,
     )
     return await Classify(cfg).run(
@@ -109,7 +113,8 @@ async def deidentify(
     max_words_per_call: int = 7500,
     guidelines: str = "",
     additional_guidelines: str = "",
-    reasoning_effort: str = "medium",
+    reasoning_effort: Optional[str] = None,
+    include_summaries: bool = False,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Deidentifier`."""
@@ -124,6 +129,7 @@ async def deidentify(
         guidelines=guidelines,
         additional_guidelines=additional_guidelines,
         reasoning_effort=reasoning_effort,
+        include_summaries=include_summaries,
         **cfg_kwargs,
     )
     return await Deidentifier(cfg).run(df, column_name, grouping_column=grouping_column)
@@ -148,7 +154,8 @@ async def rank(
     file_name: str = "rankings",
     reset_files: bool = False,
     modality: str = "text",
-    reasoning_effort: str = "medium",
+    reasoning_effort: Optional[str] = None,
+    include_summaries: bool = False,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rank`."""
@@ -169,6 +176,7 @@ async def rank(
         additional_instructions=additional_instructions or "",
         modality=modality,
         reasoning_effort=reasoning_effort,
+        include_summaries=include_summaries,
         **cfg_kwargs,
     )
     return await Rank(cfg).run(
@@ -194,7 +202,8 @@ async def codify(
     reset_files: bool = False,
     debug_print: bool = False,
     use_dummy: bool = False,
-    reasoning_effort: str = "medium",
+    reasoning_effort: Optional[str] = None,
+    include_summaries: bool = False,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Codify`."""
     os.makedirs(save_dir, exist_ok=True)
@@ -210,6 +219,7 @@ async def codify(
         n_parallels=n_parallels,
         model=model,
         reasoning_effort=reasoning_effort,
+        include_summaries=include_summaries,
         save_dir=save_dir,
         file_name=file_name,
         reset_files=reset_files,
@@ -230,7 +240,8 @@ async def whatever(
     n_parallels: int = 400,
     use_dummy: bool = False,
     reset_files: bool = False,
-    reasoning_effort: str = "medium",
+    reasoning_effort: Optional[str] = None,
+    include_summaries: bool = False,
     **kwargs,
 ) -> pd.DataFrame:
     """Wrapper around :func:`get_all_responses` for arbitrary prompts.
@@ -250,6 +261,7 @@ async def whatever(
         use_dummy=use_dummy,
         reset_files=reset_files,
         reasoning_effort=reasoning_effort,
+        include_summaries=include_summaries,
         **kwargs,
     )
 
@@ -266,7 +278,8 @@ async def custom_prompt(
     n_parallels: int = 400,
     use_dummy: bool = False,
     reset_files: bool = False,
-    reasoning_effort: str = "medium",
+    reasoning_effort: Optional[str] = None,
+    include_summaries: bool = False,
     **kwargs,
 ) -> pd.DataFrame:
     """Backward compatible alias for :func:`whatever`."""
@@ -283,6 +296,7 @@ async def custom_prompt(
         use_dummy=use_dummy,
         reset_files=reset_files,
         reasoning_effort=reasoning_effort,
+        include_summaries=include_summaries,
         **kwargs,
     )
 

--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -36,7 +36,8 @@ class ClassifyConfig:
     timeout: float = 60.0
     modality: str = "text"
     n_attributes_per_run: int = 8
-    reasoning_effort: str = "medium"
+    reasoning_effort: Optional[str] = None
+    include_summaries: bool = False
 
 
 # ────────────────────────────
@@ -200,6 +201,7 @@ class Classify:
                 use_dummy=self.cfg.use_dummy,
                 timeout=self.cfg.timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
+                include_summaries=self.cfg.include_summaries,
                 print_example_prompt=True,
                 **kwargs,
             )
@@ -239,6 +241,7 @@ class Classify:
                 use_dummy=self.cfg.use_dummy,
                 timeout=self.cfg.timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
+                include_summaries=self.cfg.include_summaries,
                 print_example_prompt=True,
                 **kwargs,
             )

--- a/src/gabriel/tasks/codify.py
+++ b/src/gabriel/tasks/codify.py
@@ -526,7 +526,8 @@ class Codify:
         reset_files: bool = False,
         debug_print: bool = False,
         use_dummy: bool = False,
-        reasoning_effort: str = "medium",
+        reasoning_effort: Optional[str] = None,
+        include_summaries: bool = False,
     ) -> pd.DataFrame:
         """
         Process all texts in the dataframe, coding passages according to categories.
@@ -634,6 +635,7 @@ class Codify:
             timeout=300,  # This will be forwarded to get_response via **kwargs
             print_example_prompt=True,
             reasoning_effort=reasoning_effort,
+            include_summaries=include_summaries,
         )
         
         # Group results by original text index and batch

--- a/src/gabriel/tasks/county_counter.py
+++ b/src/gabriel/tasks/county_counter.py
@@ -25,7 +25,8 @@ class CountyCounter:
         run_name: Optional[str] = None,
         model_regional: str = "gpt-5-mini",
         model_elo: str = "gpt-5-mini",
-        reasoning_effort: str = "medium",
+        reasoning_effort: Optional[str] = None,
+        include_summaries: bool = False,
         search_context_size: str = "medium",
         n_parallels: int = 400,
         n_elo_rounds: int = 15,
@@ -52,6 +53,7 @@ class CountyCounter:
         self.additional_guidelines = additional_guidelines
         self.elo_guidelines = elo_guidelines
         self.reasoning_effort = reasoning_effort
+        self.include_summaries = include_summaries
         self.search_context_size = search_context_size
         self.z_score_choropleth = z_score_choropleth
         self.elo_attributes = elo_attributes
@@ -68,6 +70,7 @@ class CountyCounter:
             additional_instructions=self.additional_instructions,
             additional_guidelines=self.additional_guidelines,
             reasoning_effort=self.reasoning_effort,
+            include_summaries=self.include_summaries,
             search_context_size=self.search_context_size,
             print_example_prompt=True,
             save_dir=self.save_path,
@@ -99,6 +102,8 @@ class CountyCounter:
                     additional_guidelines=self.elo_guidelines,
                     print_example_prompt=False,
                     timeout=self.elo_timeout,
+                    reasoning_effort=self.reasoning_effort,
+                    include_summaries=self.include_summaries,
                 )
             rater = EloRater(cfg)
             elo_df = await rater.run(

--- a/src/gabriel/tasks/deidentify.py
+++ b/src/gabriel/tasks/deidentify.py
@@ -26,7 +26,8 @@ class DeidentifyConfig:
     max_words_per_call: int = 7500
     guidelines: str = ""
     additional_guidelines: str = ""
-    reasoning_effort: str = "medium"
+    reasoning_effort: Optional[str] = None
+    include_summaries: bool = False
 
 
 class Deidentifier:
@@ -113,6 +114,7 @@ class Deidentifier:
                 timeout=self.cfg.timeout,
                 json_mode=True,
                 reasoning_effort=self.cfg.reasoning_effort,
+                include_summaries=self.cfg.include_summaries,
             )
             for ident, resp in zip(batch_df["Identifier"], batch_df["Response"]):
                 gid = ident.split("_seg_")[0]

--- a/src/gabriel/tasks/elo.py
+++ b/src/gabriel/tasks/elo.py
@@ -46,7 +46,8 @@ class EloConfig:
     run_name: str = f"elo_{datetime.now():%Y%m%d_%H%M%S}"
     seed: Optional[int] = None
     modality: str = "text"
-    reasoning_effort: str = "medium"
+    reasoning_effort: Optional[str] = None
+    include_summaries: bool = False
 
 
 class EloRater:
@@ -405,6 +406,7 @@ class EloRater:
                 use_dummy=self.cfg.use_dummy,
                 timeout=self.cfg.timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
+                include_summaries=self.cfg.include_summaries,
                 print_example_prompt=self.cfg.print_example_prompt,
                 **kwargs,
             )

--- a/src/gabriel/tasks/rank.py
+++ b/src/gabriel/tasks/rank.py
@@ -119,7 +119,8 @@ class RankConfig:
     additional_instructions: str = ""
     modality: str = "text"
     n_attributes_per_run: int = 8
-    reasoning_effort: str = "medium"
+    reasoning_effort: Optional[str] = None
+    include_summaries: bool = False
 
 
 class Rank:
@@ -940,6 +941,7 @@ class Rank:
                 use_dummy=self.cfg.use_dummy,
                 timeout=self._TIMEOUT,
                 reasoning_effort=self.cfg.reasoning_effort,
+                include_summaries=self.cfg.include_summaries,
                 **kwargs,
             )
             # parse each response

--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -36,7 +36,8 @@ class RateConfig:
     additional_instructions: Optional[str] = None
     modality: str = "text"
     n_attributes_per_run: int = 8
-    reasoning_effort: str = "medium"
+    reasoning_effort: Optional[str] = None
+    include_summaries: bool = False
 
 
 # ────────────────────────────
@@ -168,6 +169,7 @@ class Rate:
                 json_mode=self.cfg.modality != "audio",
                 reset_files=reset_files,
                 reasoning_effort=self.cfg.reasoning_effort,
+                include_summaries=self.cfg.include_summaries,
                 **kwargs,
             )
             df_resps = [df_resp_all]
@@ -204,6 +206,7 @@ class Rate:
                 json_mode=self.cfg.modality != "audio",
                 reset_files=reset_files,
                 reasoning_effort=self.cfg.reasoning_effort,
+                include_summaries=self.cfg.include_summaries,
                 **kwargs,
             )
 

--- a/src/gabriel/tasks/regional.py
+++ b/src/gabriel/tasks/regional.py
@@ -22,7 +22,8 @@ class RegionalConfig:
     use_dummy: bool = False
     additional_instructions: str = ""
     additional_guidelines: str = ""
-    reasoning_effort: str = "medium"
+    reasoning_effort: Optional[str] = None
+    include_summaries: bool = False
     search_context_size: str = "medium"
     print_example_prompt: bool = True
 
@@ -75,6 +76,7 @@ class Regional:
             use_web_search=True,
             search_context_size=self.cfg.search_context_size,
             reasoning_effort=self.cfg.reasoning_effort,
+            include_summaries=self.cfg.include_summaries,
             save_path=csv_path,
             reset_files=reset_files,
             use_dummy=self.cfg.use_dummy,

--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -140,7 +140,8 @@ async def clean_json_df(
     model: str = "gpt-5-mini",
     exclude_valid_json: bool = False,
     save_path: Optional[str] = None,
-    reasoning_effort: str = "medium",
+    reasoning_effort: Optional[str] = None,
+    include_summaries: bool = False,
 ) -> pd.DataFrame:
     """Ensure specified DataFrame columns contain valid JSON.
 
@@ -229,6 +230,7 @@ async def clean_json_df(
                 json_mode=True,
                 use_dummy=use_dummy,
                 reasoning_effort=reasoning_effort,
+                include_summaries=include_summaries,
                 print_example_prompt=False,
                 save_path=tmp_path,
                 reset_files=True,

--- a/src/gabriel/utils/prompt_paraphraser.py
+++ b/src/gabriel/utils/prompt_paraphraser.py
@@ -21,7 +21,8 @@ class PromptParaphraserConfig:
     save_dir: str = "paraphraser"
     use_dummy: bool = False
     timeout: float = 60.0
-    reasoning_effort: str = "medium"
+    reasoning_effort: Optional[str] = None
+    include_summaries: bool = False
 
 
 class PromptParaphraser:
@@ -46,6 +47,7 @@ class PromptParaphraser:
             use_dummy=self.cfg.use_dummy,
             timeout=self.cfg.timeout,
             reasoning_effort=self.cfg.reasoning_effort,
+            include_summaries=self.cfg.include_summaries,
         )
         return [resp[0] if isinstance(resp, list) else resp for resp in df.Response]
 


### PR DESCRIPTION
## Summary
- Add optional `include_summaries` flag across tasks and API wrappers
- Default `reasoning_effort` to `None` so reasoning is only sent when requested
- Update OpenAI helper to omit reasoning/summaries unless explicitly enabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cf0bd9d14832eb76abfe001f88d89