### PR TITLE
Update reasoning summary parameter for OpenAI API

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -673,7 +673,7 @@ def _build_params(
         if reasoning_effort is not None:
             reasoning["effort"] = reasoning_effort
         if include_summaries:
-            reasoning["include_summaries"] = True
+            reasoning["summary"] = "auto"
         if reasoning:
             params["reasoning"] = reasoning
         if model.startswith("gpt-5") and temperature != 0.9:

--- a/tests/test_reasoning_summary.py
+++ b/tests/test_reasoning_summary.py
@@ -1,0 +1,36 @@
+import pytest
+
+from gabriel.utils.openai_utils import _build_params
+
+
+def _base_args():
+    return dict(
+        model="gpt-5",
+        input_data=[{"role": "user", "content": [{"type": "text", "text": "Hi"}]}],
+        max_output_tokens=None,
+        system_instruction="",
+        temperature=0.0,
+        tools=None,
+        tool_choice=None,
+        web_search=False,
+        search_context_size="medium",
+        json_mode=False,
+        expected_schema=None,
+        reasoning_effort="low",
+    )
+
+
+def test_summary_flag_in_reasoning():
+    args = _base_args()
+    params = _build_params(**args, include_summaries=True)
+    reasoning = params.get("reasoning", {})
+    assert reasoning.get("summary") == "auto"
+    assert "include_summaries" not in reasoning
+
+
+def test_summary_absent_when_flag_false():
+    args = _base_args()
+    params = _build_params(**args, include_summaries=False)
+    reasoning = params.get("reasoning", {})
+    assert "summary" not in reasoning
+    assert "include_summaries" not in reasoning


### PR DESCRIPTION
## Summary
- replace deprecated `reasoning.include_summaries` with `reasoning.summary="auto"`
- add tests to ensure summary flag behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689cf5e21c7c832eb311f0d9555794f3