### PR TITLE
Introduce reasoning_summary parameter for reasoning control

### DIFF
--- a/county_counter.py
+++ b/county_counter.py
@@ -26,7 +26,7 @@ class CountyCounter:
         model_regional: str = "gpt-5-mini",
         model_elo: str = "gpt-5-mini",
         reasoning_effort: Optional[str] = None,
-        include_summaries: bool = False,
+        reasoning_summary: Optional[str] = None,
         search_context_size: str = "medium",
         n_parallels: int = 400,
         n_elo_rounds: int = 15,
@@ -49,7 +49,7 @@ class CountyCounter:
         self.additional_instructions = additional_instructions
         self.elo_instructions = elo_instructions
         self.reasoning_effort = reasoning_effort
-        self.include_summaries = include_summaries
+        self.reasoning_summary = reasoning_summary
         self.search_context_size = search_context_size
         self.z_score_choropleth = z_score_choropleth
         self.elo_attributes = elo_attributes
@@ -70,7 +70,7 @@ class CountyCounter:
             use_dummy=self.use_dummy,
             additional_instructions=self.additional_instructions,
             reasoning_effort=self.reasoning_effort,
-            include_summaries=self.include_summaries,
+            reasoning_summary=self.reasoning_summary,
             search_context_size=self.search_context_size,
             print_example_prompt=True,
         )
@@ -100,7 +100,7 @@ class CountyCounter:
                 print_example_prompt=False,
                 timeout=self.elo_timeout,
                 reasoning_effort=self.reasoning_effort,
-                include_summaries=self.include_summaries,
+                reasoning_summary=self.reasoning_summary,
             )
             rater = EloRater(cfg)
             elo_df = await rater.run(df_topic, text_col="text", id_col="identifier")

--- a/regional.py
+++ b/regional.py
@@ -25,7 +25,7 @@ class Regional:
         use_dummy: bool = False,
         additional_instructions: str = "",
         reasoning_effort: Optional[str] = None,
-        include_summaries: bool = False,
+        reasoning_summary: Optional[str] = None,
         search_context_size: str = "medium",
         print_example_prompt: bool = True,
     ) -> None:
@@ -37,7 +37,7 @@ class Regional:
         self.use_dummy = use_dummy
         self.additional_instructions = additional_instructions
         self.reasoning_effort = reasoning_effort
-        self.include_summaries = include_summaries
+        self.reasoning_summary = reasoning_summary
         self.search_context_size = search_context_size
         self.print_example_prompt = print_example_prompt
 
@@ -74,7 +74,7 @@ class Regional:
             use_web_search=True,
             search_context_size=self.search_context_size,
             reasoning_effort=self.reasoning_effort,
-            include_summaries=self.include_summaries,
+            reasoning_summary=self.reasoning_summary,
             save_path=csv_path,
             reset_files=reset_files,
             use_dummy=self.use_dummy,

--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -35,7 +35,7 @@ async def rate(
     file_name: str = "ratings.csv",
     modality: str = "text",
     reasoning_effort: Optional[str] = None,
-    include_summaries: bool = False,
+    reasoning_summary: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rate`."""
@@ -51,7 +51,7 @@ async def rate(
         additional_instructions=additional_instructions,
         modality=modality,
         reasoning_effort=reasoning_effort,
-        include_summaries=include_summaries,
+        reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
     return await Rate(cfg).run(
@@ -76,7 +76,7 @@ async def classify(
     file_name: str = "classify_responses.csv",
     modality: str = "text",
     reasoning_effort: Optional[str] = None,
-    include_summaries: bool = False,
+    reasoning_summary: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Classify`."""
@@ -93,7 +93,7 @@ async def classify(
         use_dummy=use_dummy,
         modality=modality,
         reasoning_effort=reasoning_effort,
-        include_summaries=include_summaries,
+        reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
     return await Classify(cfg).run(
@@ -117,7 +117,7 @@ async def deidentify(
     guidelines: str = "",
     additional_guidelines: str = "",
     reasoning_effort: Optional[str] = None,
-    include_summaries: bool = False,
+    reasoning_summary: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Deidentifier`."""
@@ -132,7 +132,7 @@ async def deidentify(
         guidelines=guidelines,
         additional_guidelines=additional_guidelines,
         reasoning_effort=reasoning_effort,
-        include_summaries=include_summaries,
+        reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
     return await Deidentifier(cfg).run(df, column_name, grouping_column=grouping_column)
@@ -158,7 +158,7 @@ async def rank(
     reset_files: bool = False,
     modality: str = "text",
     reasoning_effort: Optional[str] = None,
-    include_summaries: bool = False,
+    reasoning_summary: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rank`."""
@@ -179,7 +179,7 @@ async def rank(
         additional_instructions=additional_instructions or "",
         modality=modality,
         reasoning_effort=reasoning_effort,
-        include_summaries=include_summaries,
+        reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
     return await Rank(cfg).run(
@@ -206,7 +206,7 @@ async def codify(
     debug_print: bool = False,
     use_dummy: bool = False,
     reasoning_effort: Optional[str] = None,
-    include_summaries: bool = False,
+    reasoning_summary: Optional[str] = None,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Codify`."""
     os.makedirs(save_dir, exist_ok=True)
@@ -222,7 +222,7 @@ async def codify(
         n_parallels=n_parallels,
         model=model,
         reasoning_effort=reasoning_effort,
-        include_summaries=include_summaries,
+        reasoning_summary=reasoning_summary,
         save_dir=save_dir,
         file_name=file_name,
         reset_files=reset_files,
@@ -247,7 +247,7 @@ async def paraphrase(
     use_dummy: bool = False,
     reset_files: bool = False,
     reasoning_effort: Optional[str] = None,
-    include_summaries: bool = False,
+    reasoning_summary: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Paraphrase`."""
@@ -265,7 +265,7 @@ async def paraphrase(
         n_parallels=n_parallels,
         use_dummy=use_dummy,
         reasoning_effort=reasoning_effort,
-        include_summaries=include_summaries,
+        reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
     return await Paraphrase(cfg).run(
@@ -288,7 +288,7 @@ async def whatever(
     use_dummy: bool = False,
     reset_files: bool = False,
     reasoning_effort: Optional[str] = None,
-    include_summaries: bool = False,
+    reasoning_summary: Optional[str] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """Wrapper around :func:`get_all_responses` for arbitrary prompts.
@@ -308,7 +308,7 @@ async def whatever(
         use_dummy=use_dummy,
         reset_files=reset_files,
         reasoning_effort=reasoning_effort,
-        include_summaries=include_summaries,
+        reasoning_summary=reasoning_summary,
         **kwargs,
     )
 
@@ -326,7 +326,7 @@ async def custom_prompt(
     use_dummy: bool = False,
     reset_files: bool = False,
     reasoning_effort: Optional[str] = None,
-    include_summaries: bool = False,
+    reasoning_summary: Optional[str] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """Backward compatible alias for :func:`whatever`."""
@@ -343,7 +343,7 @@ async def custom_prompt(
         use_dummy=use_dummy,
         reset_files=reset_files,
         reasoning_effort=reasoning_effort,
-        include_summaries=include_summaries,
+        reasoning_summary=reasoning_summary,
         **kwargs,
     )
 

--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -37,7 +37,7 @@ class ClassifyConfig:
     modality: str = "text"
     n_attributes_per_run: int = 8
     reasoning_effort: Optional[str] = None
-    include_summaries: bool = False
+    reasoning_summary: Optional[str] = None
 
 
 # ────────────────────────────
@@ -201,7 +201,7 @@ class Classify:
                 use_dummy=self.cfg.use_dummy,
                 timeout=self.cfg.timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
-                include_summaries=self.cfg.include_summaries,
+                reasoning_summary=self.cfg.reasoning_summary,
                 print_example_prompt=True,
                 **kwargs,
             )
@@ -241,7 +241,7 @@ class Classify:
                 use_dummy=self.cfg.use_dummy,
                 timeout=self.cfg.timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
-                include_summaries=self.cfg.include_summaries,
+                reasoning_summary=self.cfg.reasoning_summary,
                 print_example_prompt=True,
                 **kwargs,
             )

--- a/src/gabriel/tasks/codify.py
+++ b/src/gabriel/tasks/codify.py
@@ -527,7 +527,7 @@ class Codify:
         debug_print: bool = False,
         use_dummy: bool = False,
         reasoning_effort: Optional[str] = None,
-        include_summaries: bool = False,
+        reasoning_summary: Optional[str] = None,
     ) -> pd.DataFrame:
         """
         Process all texts in the dataframe, coding passages according to categories.
@@ -635,7 +635,7 @@ class Codify:
             timeout=300,  # This will be forwarded to get_response via **kwargs
             print_example_prompt=True,
             reasoning_effort=reasoning_effort,
-            include_summaries=include_summaries,
+            reasoning_summary=reasoning_summary,
         )
         
         # Group results by original text index and batch

--- a/src/gabriel/tasks/county_counter.py
+++ b/src/gabriel/tasks/county_counter.py
@@ -26,7 +26,7 @@ class CountyCounter:
         model_regional: str = "gpt-5-mini",
         model_elo: str = "gpt-5-mini",
         reasoning_effort: Optional[str] = None,
-        include_summaries: bool = False,
+        reasoning_summary: Optional[str] = None,
         search_context_size: str = "medium",
         n_parallels: int = 400,
         n_elo_rounds: int = 15,
@@ -53,7 +53,7 @@ class CountyCounter:
         self.additional_guidelines = additional_guidelines
         self.elo_guidelines = elo_guidelines
         self.reasoning_effort = reasoning_effort
-        self.include_summaries = include_summaries
+        self.reasoning_summary = reasoning_summary
         self.search_context_size = search_context_size
         self.z_score_choropleth = z_score_choropleth
         self.elo_attributes = elo_attributes
@@ -70,7 +70,7 @@ class CountyCounter:
             additional_instructions=self.additional_instructions,
             additional_guidelines=self.additional_guidelines,
             reasoning_effort=self.reasoning_effort,
-            include_summaries=self.include_summaries,
+            reasoning_summary=self.reasoning_summary,
             search_context_size=self.search_context_size,
             print_example_prompt=True,
             save_dir=self.save_path,
@@ -103,7 +103,7 @@ class CountyCounter:
                     print_example_prompt=False,
                     timeout=self.elo_timeout,
                     reasoning_effort=self.reasoning_effort,
-                    include_summaries=self.include_summaries,
+                    reasoning_summary=self.reasoning_summary,
                 )
             rater = EloRater(cfg)
             elo_df = await rater.run(

--- a/src/gabriel/tasks/deidentify.py
+++ b/src/gabriel/tasks/deidentify.py
@@ -27,7 +27,7 @@ class DeidentifyConfig:
     guidelines: str = ""
     additional_guidelines: str = ""
     reasoning_effort: Optional[str] = None
-    include_summaries: bool = False
+    reasoning_summary: Optional[str] = None
 
 
 class Deidentifier:
@@ -114,7 +114,7 @@ class Deidentifier:
                 timeout=self.cfg.timeout,
                 json_mode=True,
                 reasoning_effort=self.cfg.reasoning_effort,
-                include_summaries=self.cfg.include_summaries,
+                reasoning_summary=self.cfg.reasoning_summary,
             )
             for ident, resp in zip(batch_df["Identifier"], batch_df["Response"]):
                 gid = ident.split("_seg_")[0]

--- a/src/gabriel/tasks/elo.py
+++ b/src/gabriel/tasks/elo.py
@@ -47,7 +47,7 @@ class EloConfig:
     seed: Optional[int] = None
     modality: str = "text"
     reasoning_effort: Optional[str] = None
-    include_summaries: bool = False
+    reasoning_summary: Optional[str] = None
 
 
 class EloRater:
@@ -406,7 +406,7 @@ class EloRater:
                 use_dummy=self.cfg.use_dummy,
                 timeout=self.cfg.timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
-                include_summaries=self.cfg.include_summaries,
+                reasoning_summary=self.cfg.reasoning_summary,
                 print_example_prompt=self.cfg.print_example_prompt,
                 **kwargs,
             )

--- a/src/gabriel/tasks/paraphrase.py
+++ b/src/gabriel/tasks/paraphrase.py
@@ -26,7 +26,7 @@ class ParaphraseConfig:
     n_parallels: int = 400
     use_dummy: bool = False
     reasoning_effort: Optional[str] = None
-    include_summaries: bool = False
+    reasoning_summary: Optional[str] = None
 
 
 class Paraphrase:
@@ -73,7 +73,7 @@ class Paraphrase:
             use_dummy=self.cfg.use_dummy,
             reset_files=reset_files,
             reasoning_effort=self.cfg.reasoning_effort,
-            include_summaries=self.cfg.include_summaries,
+            reasoning_summary=self.cfg.reasoning_summary,
             **kwargs,
         )
 

--- a/src/gabriel/tasks/rank.py
+++ b/src/gabriel/tasks/rank.py
@@ -121,7 +121,7 @@ class RankConfig:
     modality: str = "text"
     n_attributes_per_run: int = 8
     reasoning_effort: Optional[str] = None
-    include_summaries: bool = False
+    reasoning_summary: Optional[str] = None
 
 
 class Rank:
@@ -979,7 +979,7 @@ class Rank:
                 use_dummy=self.cfg.use_dummy,
                 timeout=self._TIMEOUT,
                 reasoning_effort=self.cfg.reasoning_effort,
-                include_summaries=self.cfg.include_summaries,
+                reasoning_summary=self.cfg.reasoning_summary,
                 **kwargs,
             )
             # attach metadata columns and overwrite the round CSV

--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -37,7 +37,7 @@ class RateConfig:
     modality: str = "text"
     n_attributes_per_run: int = 8
     reasoning_effort: Optional[str] = None
-    include_summaries: bool = False
+    reasoning_summary: Optional[str] = None
 
 
 # ────────────────────────────
@@ -169,7 +169,7 @@ class Rate:
                 json_mode=self.cfg.modality != "audio",
                 reset_files=reset_files,
                 reasoning_effort=self.cfg.reasoning_effort,
-                include_summaries=self.cfg.include_summaries,
+                reasoning_summary=self.cfg.reasoning_summary,
                 **kwargs,
             )
             df_resps = [df_resp_all]
@@ -206,7 +206,7 @@ class Rate:
                 json_mode=self.cfg.modality != "audio",
                 reset_files=reset_files,
                 reasoning_effort=self.cfg.reasoning_effort,
-                include_summaries=self.cfg.include_summaries,
+                reasoning_summary=self.cfg.reasoning_summary,
                 **kwargs,
             )
 

--- a/src/gabriel/tasks/regional.py
+++ b/src/gabriel/tasks/regional.py
@@ -23,7 +23,7 @@ class RegionalConfig:
     additional_instructions: str = ""
     additional_guidelines: str = ""
     reasoning_effort: Optional[str] = None
-    include_summaries: bool = False
+    reasoning_summary: Optional[str] = None
     search_context_size: str = "medium"
     print_example_prompt: bool = True
 
@@ -76,7 +76,7 @@ class Regional:
             use_web_search=True,
             search_context_size=self.cfg.search_context_size,
             reasoning_effort=self.cfg.reasoning_effort,
-            include_summaries=self.cfg.include_summaries,
+            reasoning_summary=self.cfg.reasoning_summary,
             save_path=csv_path,
             reset_files=reset_files,
             use_dummy=self.cfg.use_dummy,

--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -141,7 +141,7 @@ async def clean_json_df(
     exclude_valid_json: bool = False,
     save_path: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
-    include_summaries: bool = False,
+    reasoning_summary: Optional[str] = None,
 ) -> pd.DataFrame:
     """Ensure specified DataFrame columns contain valid JSON.
 
@@ -160,6 +160,10 @@ async def clean_json_df(
         repair invalid JSON. Defaults to ``"gpt-5-mini"``.
     reasoning_effort:
         Reasoning effort level forwarded to the model.
+    reasoning_summary:
+        Optional reasoning summary mode (e.g., ``"auto"``, ``"concise"``,
+        or ``"detailed"``) forwarded to the model. When ``None`` (default),
+        no reasoning summary is requested.
     exclude_valid_json:
         When ``False`` (default), only entries that fail to parse are sent to
         the model. When ``True``, all entries are processed regardless of
@@ -230,7 +234,7 @@ async def clean_json_df(
                 json_mode=True,
                 use_dummy=use_dummy,
                 reasoning_effort=reasoning_effort,
-                include_summaries=include_summaries,
+                reasoning_summary=reasoning_summary,
                 print_example_prompt=False,
                 save_path=tmp_path,
                 reset_files=True,

--- a/tests/test_reasoning_summary.py
+++ b/tests/test_reasoning_summary.py
@@ -22,15 +22,13 @@ def _base_args():
 
 def test_summary_flag_in_reasoning():
     args = _base_args()
-    params = _build_params(**args, include_summaries=True)
+    params = _build_params(**args, reasoning_summary="auto")
     reasoning = params.get("reasoning", {})
     assert reasoning.get("summary") == "auto"
-    assert "include_summaries" not in reasoning
 
 
-def test_summary_absent_when_flag_false():
+def test_summary_absent_when_none():
     args = _base_args()
-    params = _build_params(**args, include_summaries=False)
+    params = _build_params(**args, reasoning_summary=None)
     reasoning = params.get("reasoning", {})
     assert "summary" not in reasoning
-    assert "include_summaries" not in reasoning


### PR DESCRIPTION
## Summary
- replace `include_summaries` flag with `reasoning_summary` string option
- plumb reasoning summary option through API and task configs
- omit Reasoning Summary column when no summary requested

## Testing
- `pytest tests/test_reasoning_summary.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e25d1a2e8832e816afe9c834ace5a