### PR TITLE
Handle web search with JSON mode and tidy logging

### DIFF
--- a/src/gabriel/utils/logging.py
+++ b/src/gabriel/utils/logging.py
@@ -35,7 +35,7 @@ def _parse_level(level: Union[str, int, None]) -> int:
     return logging.INFO
 
 
-CURRENT_LEVEL = _parse_level(os.getenv("GABRIEL_LOG_LEVEL", "info"))
+CURRENT_LEVEL = _parse_level(os.getenv("GABRIEL_LOG_LEVEL", "warning"))
 
 
 def set_log_level(level: Union[str, int]) -> None:
@@ -66,13 +66,6 @@ def get_logger(name: str) -> logging.Logger:
     """Return a module logger configured with the global level."""
 
     logger = logging.getLogger(name)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
     logger.setLevel(CURRENT_LEVEL)
     return logger
 


### PR DESCRIPTION
## Summary
- warn and disable JSON mode when web search is requested
- parse codify responses with a robust JSON parser
- reduce default logging verbosity and stop duplicate log lines
- print progress every 100 rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e5756ee90832e8ec624c99ea38117