### PR TITLE
Fix coroutine cancellation in OpenAI utils

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -774,7 +774,11 @@ async def get_response(
             client_async = openai.AsyncOpenAI()
         start = time.time()
         tasks = [
-            client_async.chat.completions.create(**params_chat, timeout=timeout)
+            asyncio.create_task(
+                client_async.chat.completions.create(
+                    **params_chat, timeout=timeout
+                )
+            )
             for _ in range(max(n, 1))
         ]
         try:
@@ -854,7 +858,9 @@ async def get_response(
         start = time.time()
         # Create parallel tasks for `n` completions
         tasks = [
-            client_async.responses.create(**params, timeout=timeout)
+            asyncio.create_task(
+                client_async.responses.create(**params, timeout=timeout)
+            )
             for _ in range(max(n, 1))
         ]
         try:


### PR DESCRIPTION
## Summary
- ensure async OpenAI requests are scheduled as tasks so they can be cancelled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689eb15ec9c4832e8b5e17f5e2ee9256