### PR TITLE
Refine timeout handling and retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Key options (see `RateConfig`):
 ### `Classify`
 Classify passages into boolean labels.  Uses a prompt in `basic_classifier_prompt.jinja2` and expects JSON `{label: true/false}` responses.
 
-Options include the label dictionary, output directory, model and timeout.  Results are joined back onto the input DataFrame with one column per label.
+Options include the label dictionary, output directory, model and an optional maximum timeout.  Results are joined back onto the input DataFrame with one column per label.
 
 ### `Deidentifier`
 Iteratively remove identifying information from text.  Texts are split into manageable chunks and the model returns JSON replacement mappings which are applied across all rows.

--- a/county_counter.py
+++ b/county_counter.py
@@ -98,7 +98,7 @@ class CountyCounter:
                 use_dummy=self.use_dummy,
                 instructions=self.elo_instructions,
                 print_example_prompt=False,
-                timeout=self.elo_timeout,
+                max_timeout=self.elo_timeout,
                 reasoning_effort=self.reasoning_effort,
                 reasoning_summary=self.reasoning_summary,
             )

--- a/regional.py
+++ b/regional.py
@@ -80,7 +80,7 @@ class Regional:
             use_dummy=self.use_dummy,
             print_example_prompt=self.print_example_prompt,
             max_tokens=50000,
-            timeout=450,
+            max_timeout=450,
             **kwargs,
         )
 

--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -33,7 +33,7 @@ class ClassifyConfig:
     additional_instructions: str = ""
     additional_guidelines: str = ""
     use_dummy: bool = False
-    timeout: float = 60.0
+    max_timeout: Optional[float] = None
     modality: str = "text"
     n_attributes_per_run: int = 8
     reasoning_effort: Optional[str] = None
@@ -199,7 +199,7 @@ class Classify:
                 json_mode=self.cfg.modality != "audio",
                 model=self.cfg.model,
                 use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
+                max_timeout=self.cfg.max_timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
                 print_example_prompt=True,
@@ -239,7 +239,7 @@ class Classify:
                 json_mode=self.cfg.modality != "audio",
                 model=self.cfg.model,
                 use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
+                max_timeout=self.cfg.max_timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
                 print_example_prompt=True,

--- a/src/gabriel/tasks/codify.py
+++ b/src/gabriel/tasks/codify.py
@@ -609,7 +609,7 @@ class Codify:
             json_mode=True,
             expected_schema=expected_schema,
             model=model,
-            timeout=300,  # This will be forwarded to get_response via **kwargs
+            max_timeout=300,  # This will be forwarded to get_response via **kwargs
             print_example_prompt=True,
             reasoning_effort=reasoning_effort,
             reasoning_summary=reasoning_summary,

--- a/src/gabriel/tasks/county_counter.py
+++ b/src/gabriel/tasks/county_counter.py
@@ -101,7 +101,7 @@ class CountyCounter:
                     instructions=self.elo_instructions,
                     additional_guidelines=self.elo_guidelines,
                     print_example_prompt=False,
-                    timeout=self.elo_timeout,
+                    max_timeout=self.elo_timeout,
                     reasoning_effort=self.reasoning_effort,
                     reasoning_summary=self.reasoning_summary,
                 )

--- a/src/gabriel/tasks/deidentify.py
+++ b/src/gabriel/tasks/deidentify.py
@@ -22,7 +22,7 @@ class DeidentifyConfig:
     save_dir: str = "deidentify"
     file_name: str = "deidentified.csv"
     use_dummy: bool = False
-    timeout: float = 60.0
+    max_timeout: Optional[float] = None
     max_words_per_call: int = 7500
     guidelines: str = ""
     additional_guidelines: str = ""
@@ -111,7 +111,7 @@ class Deidentifier:
                 model=self.cfg.model,
                 save_path=f"{base_root}_round{rnd}{ext}",
                 use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
+                max_timeout=self.cfg.max_timeout,
                 json_mode=True,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,

--- a/src/gabriel/tasks/elo.py
+++ b/src/gabriel/tasks/elo.py
@@ -38,7 +38,7 @@ class EloConfig:
     n_parallels: int = 400
     model: str = "gpt-5-mini"
     use_dummy: bool = False
-    timeout: float = 45.0
+    max_timeout: Optional[float] = None
     print_example_prompt: bool = True
     instructions: str = ""
     additional_guidelines: str = ""
@@ -404,7 +404,7 @@ class EloRater:
                 save_path=os.path.join(self.save_path, f"round{rnd}.csv"),
                 reset_files=reset_files,
                 use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
+                max_timeout=self.cfg.max_timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
                 print_example_prompt=self.cfg.print_example_prompt,

--- a/src/gabriel/tasks/rank.py
+++ b/src/gabriel/tasks/rank.py
@@ -190,11 +190,11 @@ class Rank:
         # 200 000, each item will only consider approximately 20 neighbours.
         self._MAX_CANDIDATE_PAIRS_PER_ROUND = 200_000
 
-        # timeout in seconds for a batch of language model responses.  Not
-        # exposed publicly because changing it rarely benefits typical
+        # maximum timeout in seconds for a batch of language model responses.
+        # not exposed publicly because changing it rarely benefits typical
         # workloads; if a different timeout is required this can be
         # modified here.
-        self._TIMEOUT = 90.0
+        self._MAX_TIMEOUT = 90.0
 
     # ------------------------------------------------------------------
     # Public API for adding multiway rankings
@@ -977,7 +977,8 @@ class Rank:
                 save_path=round_path,
                 reset_files=reset_files,
                 use_dummy=self.cfg.use_dummy,
-                timeout=self._TIMEOUT,
+                max_timeout=self._MAX_TIMEOUT,
+                max_retries=1,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
                 **kwargs,

--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -31,7 +31,7 @@ class RateConfig:
     n_parallels: int = 400
     n_runs: int = 1
     use_dummy: bool = False
-    timeout: float = 75.0
+    max_timeout: Optional[float] = None
     rating_scale: Optional[str] = None
     additional_instructions: Optional[str] = None
     modality: str = "text"
@@ -165,7 +165,7 @@ class Rate:
                 model=self.cfg.model,
                 save_path=csv_path,
                 use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
+                max_timeout=self.cfg.max_timeout,
                 json_mode=self.cfg.modality != "audio",
                 reset_files=reset_files,
                 reasoning_effort=self.cfg.reasoning_effort,
@@ -202,7 +202,7 @@ class Rate:
                 model=self.cfg.model,
                 save_path=csv_path,
                 use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
+                max_timeout=self.cfg.max_timeout,
                 json_mode=self.cfg.modality != "audio",
                 reset_files=reset_files,
                 reasoning_effort=self.cfg.reasoning_effort,

--- a/src/gabriel/tasks/regional.py
+++ b/src/gabriel/tasks/regional.py
@@ -82,7 +82,7 @@ class Regional:
             use_dummy=self.cfg.use_dummy,
             print_example_prompt=self.cfg.print_example_prompt,
             max_tokens=50000,
-            timeout=450,
+            max_timeout=450,
             **kwargs,
         )
 


### PR DESCRIPTION
## Summary
- default `max_timeout` to `None` and drop deprecated `timeout` parameter
- scale retry timeouts by 1.5× and store per-task limits
- wire rank task to use `max_retries=1` and pass `max_timeout`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f971eb4f0832e8eac0ae7480e37f4