### PR TITLE
Skip disaggregated saves when single run

### DIFF
--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -289,8 +289,11 @@ class Classify:
             )
 
         full_df = pd.DataFrame(full_records).set_index(["text", "run"])
-        disagg_path = os.path.join(self.cfg.save_dir, f"{base_name}_full_disaggregated.csv")
-        full_df.to_csv(disagg_path, index_label=["text", "run"])
+        if self.cfg.n_runs > 1:
+            disagg_path = os.path.join(
+                self.cfg.save_dir, f"{base_name}_full_disaggregated.csv"
+            )
+            full_df.to_csv(disagg_path, index_label=["text", "run"])
 
         # aggregate across runs using a minimum frequency threshold
         def _min_freq(s: pd.Series) -> Optional[bool]:

--- a/src/gabriel/tasks/extract.py
+++ b/src/gabriel/tasks/extract.py
@@ -218,8 +218,11 @@ class Extract:
                 full_records.append(rec)
 
         full_df = pd.DataFrame(full_records).set_index(["id", "run"])
-        disagg_path = os.path.join(self.cfg.save_dir, f"{base_name}_full_disaggregated.csv")
-        full_df.to_csv(disagg_path, index_label=["id", "run"])
+        if self.cfg.n_runs > 1:
+            disagg_path = os.path.join(
+                self.cfg.save_dir, f"{base_name}_full_disaggregated.csv"
+            )
+            full_df.to_csv(disagg_path, index_label=["id", "run"])
 
         def _pick_first(s: pd.Series) -> str:
             for val in s.dropna():

--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -247,8 +247,11 @@ class Rate:
                 full_records.append(rec)
 
         full_df = pd.DataFrame(full_records).set_index(["id", "run"])
-        disagg_path = os.path.join(self.cfg.save_dir, f"{base_name}_full_disaggregated.csv")
-        full_df.to_csv(disagg_path, index_label=["id", "run"])
+        if self.cfg.n_runs > 1:
+            disagg_path = os.path.join(
+                self.cfg.save_dir, f"{base_name}_full_disaggregated.csv"
+            )
+            full_df.to_csv(disagg_path, index_label=["id", "run"])
 
         # aggregate across runs
         agg_df = full_df.groupby("id")[list(self.cfg.attributes)].mean()


### PR DESCRIPTION
## Summary
- Only write disaggregated CSVs when tasks are run with multiple runs
- Applies to Rate, Extract, and Classify tasks

## Testing
- `pip install pytest-asyncio`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a654393274832eb8c6f6d7bd1b4dd0