### PR TITLE
Fix merge normalization for HTML entities

### DIFF
--- a/src/gabriel/tasks/merge.py
+++ b/src/gabriel/tasks/merge.py
@@ -7,6 +7,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+import html
+import unicodedata
+
 import numpy as np
 import pandas as pd
 from scipy.cluster.vq import kmeans2
@@ -47,7 +50,10 @@ class Merge:
     @staticmethod
     def _normalize(val: str) -> str:
         """Normalize strings for fuzzy matching."""
-        return re.sub(r"[^0-9a-z]+", "", val.lower())
+        # Convert HTML entities and strip accents before keeping alphanumeric
+        txt = html.unescape(val).lower()
+        txt = unicodedata.normalize("NFKD", txt)
+        return "".join(ch for ch in txt if ch.isalnum())
 
     @classmethod
     def _deduplicate(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -49,3 +49,16 @@ def test_merge_trailing_space(mock_resp, tmp_path):
     df2 = pd.DataFrame({"val": [1], "term": ["Apple"]})
     merged = asyncio.run(task.run(df1, df2, on="term"))
     assert merged["val"].iloc[0] == 1
+
+
+@patch("gabriel.tasks.merge.get_all_responses", new_callable=AsyncMock)
+def test_merge_html_entities(mock_resp, tmp_path):
+    mock_resp.return_value = pd.DataFrame(
+        {"Identifier": ["merge_00000"], "Response": ['{"B. Pôssas": "B. Pôssas"}']}
+    )
+    cfg = MergeConfig(save_dir=str(tmp_path), use_embeddings=False)
+    task = Merge(cfg)
+    df1 = pd.DataFrame({"term": ["B. Pôssas"]})
+    df2 = pd.DataFrame({"val": [1], "term": ["B. P&#244;ssas"]})
+    merged = asyncio.run(task.run(df1, df2, on="term"))
+    assert merged["val"].iloc[0] == 1


### PR DESCRIPTION
## Summary
- Unescape HTML entities and strip accents when normalizing merge keys
- Add regression test for HTML encoded merge values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a65de9d6d0832e8da3da2082326bc3