### PR TITLE
Randomize circle_first prompts and support n_runs in Rank

### DIFF
--- a/src/gabriel/prompts/classification_prompt.jinja2
+++ b/src/gabriel/prompts/classification_prompt.jinja2
@@ -1,6 +1,6 @@
 {% import "snippets.jinja2" as snip %}
 {% if differentiate %}
-{{ snip.pair_entries(modality, entry_square, entry_circle) }}
+{{ snip.pair_entries(modality, entry_square, entry_circle, circle_first=circle_first|default(false)) }}
 You are specifically looking at features that distinguish the following two passages from each other.
 When deciding which bucket terms apply, what that means is whether the bucket term in question captures a key difference between the two passages.
 Pay close attention to the specific passage type, square or circle.

--- a/src/gabriel/prompts/codify_prompt.jinja2
+++ b/src/gabriel/prompts/codify_prompt.jinja2
@@ -1,6 +1,6 @@
 {% import "snippets.jinja2" as snip %}
 {% if entry_circle is defined %}
-{{ snip.pair_entries(modality, entry_square, entry_circle) }}
+{{ snip.pair_entries(modality, entry_square, entry_circle, circle_first=circle_first|default(false)) }}
 {% else %}
 {{ snip.single_entry(modality, text) }}
 {% endif %}

--- a/src/gabriel/prompts/comparison_prompt.jinja2
+++ b/src/gabriel/prompts/comparison_prompt.jinja2
@@ -1,5 +1,5 @@
 {% import "snippets.jinja2" as snip %}
-{{ snip.pair_entries(modality, entry_square, entry_circle) }}
+{{ snip.pair_entries(modality, entry_square, entry_circle, circle_first=circle_first|default(false)) }}
 
 {% if differentiate %}
 Your task is to list concise, mutually exclusive terms or short phrases that best explain how entry "circle" differs from entry "square".

--- a/src/gabriel/prompts/rankings_prompt.jinja2
+++ b/src/gabriel/prompts/rankings_prompt.jinja2
@@ -1,5 +1,5 @@
 {% import "snippets.jinja2" as snip %}
-{{ snip.pair_entries(modality, entry_square, entry_circle) }}
+{{ snip.pair_entries(modality, entry_square, entry_circle, circle_first=circle_first|default(false)) }}
 
 Essential: do not confuse or conflate the two entries.
 Fully separate entry square from entry circle in your mind.

--- a/src/gabriel/prompts/snippets.jinja2
+++ b/src/gabriel/prompts/snippets.jinja2
@@ -23,9 +23,18 @@ Crucial: ONLY use the direct info you find on the web to perform your analysis. 
 {% endif %}
 {% endmacro %}
 
-{% macro pair_entries(modality, entry_square, entry_circle) %}
+{% macro pair_entries(modality, entry_square, entry_circle, circle_first=False) %}
 {% if modality == "text" %}
 Consider the following two distinct text entries:
+{% if circle_first %}
+BEGIN ENTRY CIRCLE
+{{ entry_circle }}
+END ENTRY CIRCLE
+Above entry ("circle") is distinct from below entry ("square").
+BEGIN ENTRY SQUARE
+{{ entry_square }}
+END ENTRY SQUARE
+{% else %}
 BEGIN ENTRY SQUARE
 {{ entry_square }}
 END ENTRY SQUARE
@@ -33,25 +42,56 @@ Above entry ("square") is distinct from below entry ("circle").
 BEGIN ENTRY CIRCLE
 {{ entry_circle }}
 END ENTRY CIRCLE
+{% endif %}
 
 Read both text entries separately from one another. Process each by itself and fully-start, middle, end.
 Do not skim; comprehend each whole text deeply, including subtleties buried deep in each text entry.
 Understand every nuance before comparing.
 {% elif modality == "image" %}
+{% if circle_first %}
+Two images are provided. **CIRCLE = first image. SQUARE = second image.** Comprehend both fully (overall + fine detail).
+Again, "square" references the second, later image entry; "circle" references the first, earlier image entry.
+Be very clear in your mind that "circle" is the first image and "square" is the second image.
+{% else %}
 Two images are provided. **SQUARE = first image. CIRCLE = second image.** Comprehend both fully (overall + fine detail).
 Again, "circle" references the second, later image entry; "square" references the first, earlier image entry.
 Be very clear in your mind that "square" is the first image and "circle" is the second image.
+{% endif %}
 {% elif modality == "audio" %}
+{% if circle_first %}
+Two audio files are provided. **CIRCLE = first audio recording. SQUARE = second audio recording.** Comprehend both fully (content, style, tone, sonic qualities).
+Again, "square" references the second, later audio entry; "circle" references the first, earlier audio entry.
+Be very clear in your mind that "circle" is the first audio recording and "square" is the second audio recording.
+{% else %}
 Two audio files are provided. **SQUARE = first audio recording. CIRCLE = second audio recording.** Comprehend both fully (content, style, tone, sonic qualities).
 Again, "circle" references the second, later audio entry; "square" references the first, earlier audio entry.
 Be very clear in your mind that "square" is the first audio recording and "circle" is the second audio recording.
+{% endif %}
 {% elif modality == "entity" %}
+{% if circle_first %}
+Entity circle: {{ entry_circle }}
+Entity square: {{ entry_square }}
+Use your prodigious internal knowledge on both item/entity square ("{{ entry_square }}") and item/entity circle ("{{ entry_circle }}").
+Comprehensively consider every relevant detail you know about each, both big picture and subtleties.
+Consider "{{ entry_square }}" ("square") and "{{ entry_circle }}" ("circle") as the entries/content to be compared, using your internal knowledge.
+{% else %}
 Entity square: {{ entry_square }}
 Entity circle: {{ entry_circle }}
 Use your prodigious internal knowledge on both item/entity circle ("{{ entry_circle }}") and item/entity square ("{{ entry_square }}").
 Comprehensively consider every relevant detail you know about each, both big picture and subtleties.
 Consider "{{ entry_circle }}" ("circle") and "{{ entry_square }}" ("square") as the entries/content to be compared, using your internal knowledge.
+{% endif %}
 {% elif modality == "web" %}
+{% if circle_first %}
+Entity circle: {{ entry_circle }}
+Entity square: {{ entry_square }}
+Comprehensively explore the web for all relevant information on both item/entity square ("{{ entry_square }}") and item/entity circle ("{{ entry_circle }}").
+Ensure you collect a highly truthful, accurate, comprehensive, and representative picture of each from the web.
+Critical that you search on each entity separately and with equal thoroughness.
+Consider "{{ entry_square }}" ("square") and "{{ entry_circle }}" ("circle") as the entries/content to be compared, fully grounded in the info you find on the web.
+Thoroughly research each entity on the web; creatively use different search approaches; gather as much info as possible to deeply characterize the relevant aspects of both square and circle.
+Crucial: ONLY use the direct info you find on the web to perform your analysis. Collect the info then dispassionately analyze it with no preconceived notions.
+{% else %}
 Entity square: {{ entry_square }}
 Entity circle: {{ entry_circle }}
 Comprehensively explore the web for all relevant information on both item/entity circle ("{{ entry_circle }}") and item/entity square ("{{ entry_square }}").
@@ -60,5 +100,6 @@ Critical that you search on each entity separately and with equal thoroughness.
 Consider "{{ entry_circle }}" ("circle") and "{{ entry_square }}" ("square") as the entries/content to be compared, fully grounded in the info you find on the web.
 Thoroughly research each entity on the web; creatively use different search approaches; gather as much info as possible to deeply characterize the relevant aspects of both circle and square.
 Crucial: ONLY use the direct info you find on the web to perform your analysis. Collect the info then dispassionately analyze it with no preconceived notions.
+{% endif %}
 {% endif %}
 {% endmacro %}

--- a/src/gabriel/tasks/compare.py
+++ b/src/gabriel/tasks/compare.py
@@ -16,7 +16,6 @@ from ..utils import (
     safest_json,
     load_image_inputs,
     load_audio_inputs,
-    swap_circle_square,
 )
 
 
@@ -82,9 +81,6 @@ class Compare:
         prompts: List[str] = []
         ids: List[str] = []
         id_to_circle_first: Dict[str, bool] = {}
-        base_template = self.template.text
-        tmpl_square = PromptTemplate(base_template)
-        tmpl_circle = PromptTemplate(swap_circle_square(base_template))
         for circle, square in pairs:
             ident = hashlib.sha1(f"{circle}|{square}".encode()).hexdigest()[:8]
             ids.append(ident)
@@ -100,14 +96,14 @@ class Compare:
             square_text = (
                 square if self.cfg.modality in {"text", "entity", "web"} else ""
             )
-            tmpl = tmpl_circle if circle_first_flag else tmpl_square
             prompts.append(
-                tmpl.render(
+                self.template.render(
                     entry_circle=circle_text,
                     entry_square=square_text,
                     differentiate=self.cfg.differentiate,
                     additional_instructions=self.cfg.additional_instructions or "",
                     modality=self.cfg.modality,
+                    circle_first=circle_first_flag,
                 )
             )
 


### PR DESCRIPTION
## Summary
- add a `circle_first` flag to the `pair_entries` macro so text/image/audio/entity/web prompts can render circle-first prompts when desired
- update `compare`, `classify`, and `rank` to pass the `circle_first` value directly to templates instead of swapping prompt text
- allow `Rank.run` to accept an `n_runs` parameter, printing a helpful notice so accidental `Rate` parameters do not raise an error

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_i_68a7c0329efc832eb96c5bffce700334