### PR TITLE
Ensure final cost summary is printed

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -1297,9 +1297,11 @@ async def get_all_responses(
         else:
             avg_row = 0.0
             avg_1000 = 0.0
-        logger.info(
+        msg = (
             f"Total cost: ${total_cost:.4f}; average per row: ${avg_row:.4f}; average per 1000 rows: ${avg_1000:.4f}"
         )
+        print(msg)
+        logger.info(msg)
     # Filter prompts/identifiers based on what is already completed
     todo_pairs = [(p, i) for p, i in zip(prompts, identifiers) if i not in done]
     if not todo_pairs:


### PR DESCRIPTION
## Summary
- ensure the cost summary in `get_all_responses` is printed to the console while still being logged
- the summary now uses a formatted message that is both printed and logged so users see it even when the logging level is set to warning

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_i_68a8c345e8f8832e81ec1766472c265d