### PR TITLE
Refine merge candidate selection and handle no-match outputs

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -66,6 +66,19 @@ def test_merge_html_entities(mock_resp, tmp_path):
 
 
 @patch("gabriel.tasks.merge.get_all_responses", new_callable=AsyncMock)
+def test_merge_no_certain_match(mock_resp, tmp_path):
+    mock_resp.return_value = pd.DataFrame(
+        {"Identifier": ["merge_00_00000"], "Response": ['{"apple": "no certain match"}']}
+    )
+    cfg = MergeConfig(save_dir=str(tmp_path), use_embeddings=False)
+    task = Merge(cfg)
+    df1 = pd.DataFrame({"term": ["apple"]})
+    df2 = pd.DataFrame({"val": [1], "term": ["Apple"]})
+    merged = asyncio.run(task.run(df1, df2, on="term"))
+    assert pd.isna(merged["val"].iloc[0])
+
+
+@patch("gabriel.tasks.merge.get_all_responses", new_callable=AsyncMock)
 def test_merge_max_attempts(mock_resp, tmp_path):
     mock_resp.side_effect = [
         pd.DataFrame({"Identifier": ["merge_00_00000"], "Response": ['{"apple": "Apple"}']}),


### PR DESCRIPTION
## Summary
- Skip 'no certain match' entries when tallying Merge results
- Replace centroid-based long-list selection with per-term nearest neighbors
- Add regression test for 'no certain match' responses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gabriel.utils.teleprompter')*
- `pytest tests/test_merge.py -q`


------
https://chatgpt.com/codex/tasks/task_i_68a8f87ce838832e9e5523b656c72a09