### PR TITLE
Clarify OpenAI utils and fix async test

### DIFF
--- a/tests/test_input_image_url.py
+++ b/tests/test_input_image_url.py
@@ -1,21 +1,36 @@
-import pytest
+import asyncio
 import openai
 from gabriel.utils import openai_utils
 
 class DummyClient:
+    """Minimal stand‑in for the OpenAI client used in tests.
+
+    The object captures the parameters passed to ``create`` so the test can
+    inspect them without making real API calls.  The method is ``async`` to
+    mirror the behaviour of the real client.
+    """
+
     def __init__(self):
         self.responses = self
+
     async def create(self, **kwargs):
         DummyClient.captured = kwargs
+
         class Resp:
             output_text = "ok"
+
         return Resp()
 
-@pytest.mark.asyncio
-async def test_get_response_encodes_image(monkeypatch):
+
+def test_get_response_encodes_image(monkeypatch):
+    """Verify that image strings are converted to data URLs before sending."""
+
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     openai_utils.client_async = None
     dummy = DummyClient()
     monkeypatch.setattr(openai, "AsyncOpenAI", lambda: dummy)
-    await openai_utils.get_response("Describe", images=["abc"], use_dummy=False)
-    assert DummyClient.captured["input"][0]["content"][1]["image_url"] == "data:image/jpeg;base64,abc"
+    asyncio.run(openai_utils.get_response("Describe", images=["abc"], use_dummy=False))
+    assert (
+        DummyClient.captured["input"][0]["content"][1]["image_url"]
+        == "data:image/jpeg;base64,abc"
+    )


### PR DESCRIPTION
## Summary
- fix async image-url unit test by running coroutine with `asyncio.run`
- expand and clarify documentation for OpenAI helper functions
- add `web_search` parameter (deprecating `use_web_search`) to align naming

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68acc1ca4d1c832eac7044817694daa1