### PR TITLE
Add Filter task for conditional entity screening

### DIFF
--- a/src/gabriel/__init__.py
+++ b/src/gabriel/__init__.py
@@ -15,6 +15,7 @@ from .api import (
     discover,
     deduplicate,
     merge,
+    filter,
     whatever,
     view_coded_passages,
 )
@@ -37,6 +38,7 @@ __all__ = list(_tasks.__all__) + [
     "discover",
     "deduplicate",
     "merge",
+    "filter",
     "whatever",
     "view_coded_passages",
     "load_files",

--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -27,6 +27,8 @@ from .tasks import (
     BucketConfig,
     Discover,
     DiscoverConfig,
+    Filter,
+    FilterConfig,
 )
 from .utils.openai_utils import get_all_responses
 from .utils.passage_viewer import view_coded_passages as _view_coded_passages
@@ -597,6 +599,53 @@ async def merge(
         left_on=left_on,
         right_on=right_on,
         how=how,
+        reset_files=reset_files,
+    )
+
+
+async def filter(
+    df: pd.DataFrame,
+    column_name: str,
+    *,
+    condition: str,
+    save_dir: str,
+    entities_per_call: int = 150,
+    shuffle: bool = True,
+    random_seed: int = 42,
+    n_runs: int = 1,
+    threshold: float = 0.5,
+    additional_instructions: Optional[str] = None,
+    model: str = "gpt-5-mini",
+    n_parallels: int = 750,
+    reset_files: bool = False,
+    use_dummy: bool = False,
+    file_name: str = "filter_responses.csv",
+    max_timeout: Optional[float] = None,
+    **cfg_kwargs,
+) -> pd.DataFrame:
+    """Convenience wrapper for :class:`gabriel.tasks.Filter`."""
+
+    save_dir = os.path.expandvars(os.path.expanduser(save_dir))
+    os.makedirs(save_dir, exist_ok=True)
+    cfg = FilterConfig(
+        condition=condition,
+        save_dir=save_dir,
+        file_name=file_name,
+        model=model,
+        n_parallels=n_parallels,
+        entities_per_call=entities_per_call,
+        shuffle=shuffle,
+        random_seed=random_seed,
+        n_runs=n_runs,
+        threshold=threshold,
+        additional_instructions=additional_instructions or "",
+        use_dummy=use_dummy,
+        max_timeout=max_timeout,
+        **cfg_kwargs,
+    )
+    return await Filter(cfg).run(
+        df,
+        column_name,
         reset_files=reset_files,
     )
 

--- a/src/gabriel/tasks/__init__.py
+++ b/src/gabriel/tasks/__init__.py
@@ -33,6 +33,8 @@ _lazy_imports = {
     "BucketConfig": ".bucket",
     "Discover": ".discover",
     "DiscoverConfig": ".discover",
+    "Filter": ".filter",
+    "FilterConfig": ".filter",
 }
 
 __all__ = list(_lazy_imports.keys())

--- a/src/gabriel/tasks/filter.py
+++ b/src/gabriel/tasks/filter.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import os
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from ..core.prompt_template import PromptTemplate
+from ..utils.openai_utils import get_all_responses
+from ..utils import safest_json
+
+
+@dataclass
+class FilterConfig:
+    """Configuration for :class:`Filter`."""
+
+    condition: str
+    save_dir: str
+    file_name: str = "filter_responses.csv"
+    model: str = "gpt-5-mini"
+    n_parallels: int = 750
+    entities_per_call: int = 150
+    shuffle: bool = True
+    random_seed: int = 42
+    n_runs: int = 1
+    threshold: float = 0.5
+    additional_instructions: str = ""
+    use_dummy: bool = False
+    max_timeout: Optional[float] = None
+
+
+class Filter:
+    """Filter entities in a DataFrame column based on a condition using an LLM."""
+
+    def __init__(self, cfg: FilterConfig, template: Optional[PromptTemplate] = None) -> None:
+        expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
+        expanded.mkdir(parents=True, exist_ok=True)
+        cfg.save_dir = str(expanded)
+        self.cfg = cfg
+        self.template = template or PromptTemplate.from_package("filter_prompt.jinja2")
+
+    # ------------------------------------------------------------------
+    async def run(
+        self,
+        df: pd.DataFrame,
+        column_name: str,
+        *,
+        reset_files: bool = False,
+        **kwargs: Any,
+    ) -> pd.DataFrame:
+        df_proc = df.reset_index(drop=True).copy()
+        raw_entities = [str(x) for x in df_proc[column_name].dropna()]
+
+        # unique while preserving order
+        seen: set[str] = set()
+        entities: List[str] = []
+        for ent in raw_entities:
+            if ent not in seen:
+                seen.add(ent)
+                entities.append(ent)
+
+        prompts: List[str] = []
+        identifiers: List[str] = []
+        for run in range(self.cfg.n_runs):
+            ents = list(entities)
+            if self.cfg.shuffle:
+                rnd = random.Random(self.cfg.random_seed + run)
+                rnd.shuffle(ents)
+            chunks = [
+                ents[i : i + self.cfg.entities_per_call]
+                for i in range(0, len(ents), self.cfg.entities_per_call)
+            ]
+            for idx, chunk in enumerate(chunks):
+                prompts.append(
+                    self.template.render(
+                        condition=self.cfg.condition,
+                        entities="\n".join(chunk),
+                        additional_instructions=self.cfg.additional_instructions,
+                    )
+                )
+                identifiers.append(f"filter_{run:03d}_{idx:05d}")
+
+        save_path = os.path.join(self.cfg.save_dir, self.cfg.file_name)
+        if prompts:
+            resp_df = await get_all_responses(
+                prompts=prompts,
+                identifiers=identifiers,
+                n_parallels=self.cfg.n_parallels,
+                model=self.cfg.model,
+                save_path=save_path,
+                use_dummy=self.cfg.use_dummy,
+                max_timeout=self.cfg.max_timeout,
+                json_mode=True,
+                reset_files=reset_files,
+                **kwargs,
+            )
+        else:
+            resp_df = pd.DataFrame(columns=["Identifier", "Response"])
+
+        resp_map: Dict[str, Any] = dict(
+            zip(resp_df.get("Identifier", []), resp_df.get("Response", []))
+        )
+
+        meets_by_run: List[set[str]] = [set() for _ in range(self.cfg.n_runs)]
+        for ident, raw in resp_map.items():
+            parts = ident.split("_")
+            if len(parts) < 3:
+                continue
+            try:
+                run_idx = int(parts[1])
+            except ValueError:
+                continue
+            parsed = await safest_json(raw)
+            ent_list: Optional[List[str]] = None
+            if isinstance(parsed, dict):
+                val = parsed.get("entities meeting condition") or parsed.get(
+                    "entities_meeting_condition"
+                )
+                if isinstance(val, list):
+                    ent_list = [str(v) for v in val if isinstance(v, str)]
+            elif isinstance(parsed, list):
+                ent_list = [str(v) for v in parsed if isinstance(v, str)]
+            if ent_list and 0 <= run_idx < self.cfg.n_runs:
+                for ent in ent_list:
+                    meets_by_run[run_idx].add(ent.strip())
+
+        run_cols: List[str] = []
+        for run_idx in range(self.cfg.n_runs):
+            meets_norm = {m.lower() for m in meets_by_run[run_idx]}
+            col = f"meets_condition_run_{run_idx + 1}"
+            run_cols.append(col)
+            df_proc[col] = [
+                str(v).lower() in meets_norm if not pd.isna(v) else False
+                for v in df_proc[column_name]
+            ]
+
+        df_proc["meets_condition"] = (
+            df_proc[run_cols].sum(axis=1) / self.cfg.n_runs >= self.cfg.threshold
+        )
+        return df_proc

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,97 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+
+import gabriel
+from gabriel.tasks.filter import Filter, FilterConfig
+
+
+async def _run_filter(tmp_path):
+    cfg = FilterConfig(
+        condition="contains a",
+        save_dir=str(tmp_path),
+        entities_per_call=2,
+        shuffle=False,
+    )
+    task = Filter(cfg)
+    df = pd.DataFrame({"tech": ["apple", "banana", "orange"]})
+    return await task.run(df, "tech")
+
+
+@patch("gabriel.tasks.filter.get_all_responses", new_callable=AsyncMock)
+def test_filter_task(mock_resp, tmp_path):
+    mock_resp.return_value = pd.DataFrame(
+        {
+            "Identifier": ["filter_000_00000", "filter_000_00001"],
+            "Response": [
+                '{"entities meeting condition": ["apple"]}',
+                '{"entities meeting condition": ["orange"]}',
+            ],
+        }
+    )
+    result = asyncio.run(_run_filter(tmp_path))
+    assert list(result["meets_condition"]) == [True, False, True]
+
+
+@patch("gabriel.tasks.filter.get_all_responses", new_callable=AsyncMock)
+def test_filter_api(mock_resp, tmp_path):
+    mock_resp.return_value = pd.DataFrame(
+        {
+            "Identifier": ["filter_000_00000", "filter_000_00001"],
+            "Response": [
+                '{"entities meeting condition": ["apple"]}',
+                '{"entities meeting condition": ["orange"]}',
+            ],
+        }
+    )
+    df = pd.DataFrame({"tech": ["apple", "banana", "orange"]})
+    result = asyncio.run(
+        gabriel.filter(
+            df,
+            "tech",
+            condition="contains a",
+            save_dir=str(tmp_path),
+            entities_per_call=2,
+            shuffle=False,
+        )
+    )
+    assert list(result["meets_condition"]) == [True, False, True]
+
+
+@patch("gabriel.tasks.filter.get_all_responses", new_callable=AsyncMock)
+def test_filter_task_n_runs(mock_resp, tmp_path):
+    mock_resp.return_value = pd.DataFrame(
+        {
+            "Identifier": [
+                "filter_000_00000",
+                "filter_000_00001",
+                "filter_001_00000",
+                "filter_001_00001",
+                "filter_002_00000",
+                "filter_002_00001",
+            ],
+            "Response": [
+                '{"entities meeting condition": ["apple"]}',
+                '{"entities meeting condition": ["orange"]}',
+                '{"entities meeting condition": ["apple", "banana"]}',
+                '{"entities meeting condition": []}',
+                '{"entities meeting condition": []}',
+                '{"entities meeting condition": ["orange"]}',
+            ],
+        }
+    )
+    cfg = FilterConfig(
+        condition="contains a",
+        save_dir=str(tmp_path),
+        entities_per_call=2,
+        shuffle=False,
+        n_runs=3,
+    )
+    task = Filter(cfg)
+    df = pd.DataFrame({"tech": ["apple", "banana", "orange"]})
+    result = asyncio.run(task.run(df, "tech"))
+    assert list(result["meets_condition_run_1"]) == [True, False, True]
+    assert list(result["meets_condition_run_2"]) == [True, True, False]
+    assert list(result["meets_condition_run_3"]) == [False, False, True]
+    assert list(result["meets_condition"]) == [True, False, True]


### PR DESCRIPTION
## Summary
- add multi-run Filter task with deterministic shuffling and run aggregation
- expose random seed, run count and threshold in `gabriel.filter`
- exercise new behavior with extended unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_i_68acf2449c94832eb2cd624811e7691d