### PR TITLE
Add multi-run deduplicate support and clarify JSON helpers

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -511,7 +511,7 @@ async def deduplicate(
     additional_instructions: Optional[str] = None,
     model: str = "gpt-5-mini",
     n_parallels: int = 750,
-    n_runs: int = 1,
+    n_runs: int = 3,
     reset_files: bool = False,
     use_dummy: bool = False,
     file_name: str = "deduplicate_responses.csv",

--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -99,7 +99,12 @@ def _parse_json(txt: Any) -> Union[dict, list]:
 
 
 def safe_json(txt: Any) -> Union[dict, list]:
-    """Best-effort JSON parser returning ``{}`` on failure."""
+    """Best-effort JSON parser returning ``{}`` on failure.
+
+    This helper runs synchronously and never uses the LLM; it simply applies a
+    number of heuristics locally to coerce ``txt`` into a JSON object or list.
+    """
+
     try:
         return _parse_json(txt)
     except Exception:
@@ -107,7 +112,13 @@ def safe_json(txt: Any) -> Union[dict, list]:
 
 
 async def safest_json(txt: Any, *, model: Optional[str] = None) -> Union[dict, list]:
-    """Async wrapper around :func:`safe_json` with optional LLM fixup."""
+    """Parse JSON and optionally invoke an LLM to repair malformed input.
+
+    When local parsing fails, this function can ask a model to reformat the
+    given text into valid JSON.  Use it when ``safe_json`` is insufficient and
+    a best-effort LLM fix is desired.
+    """
+
     try:
         return _parse_json(txt)
     except Exception:

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -4,14 +4,22 @@ import pandas as pd
 from gabriel.tasks.deduplicate import Deduplicate, DeduplicateConfig
 
 
-async def _run_dedup(tmp_path):
-    cfg = DeduplicateConfig(save_dir=str(tmp_path), use_dummy=True, use_embeddings=False)
+async def _run_dedup(tmp_path, n_runs=1):
+    cfg = DeduplicateConfig(save_dir=str(tmp_path), use_dummy=True, use_embeddings=False, n_runs=n_runs)
     task = Deduplicate(cfg)
     df = pd.DataFrame({"term": ["apple", "Apple", "banana", "BANANA", "pear"]})
     return await task.run(df, on="term")
 
 
 def test_deduplicate_dummy(tmp_path):
-    result = asyncio.run(_run_dedup(tmp_path))
+    result = asyncio.run(_run_dedup(tmp_path, n_runs=1))
+    assert "mapped_term" in result.columns
+    assert result["mapped_term"].tolist() == ["apple", "apple", "banana", "banana", "pear"]
+
+
+def test_deduplicate_multiple_runs(tmp_path):
+    result = asyncio.run(_run_dedup(tmp_path, n_runs=2))
+    assert "mapped_term_run1" in result.columns
+    assert "mapped_term_final" in result.columns
     assert "mapped_term" in result.columns
     assert result["mapped_term"].tolist() == ["apple", "apple", "banana", "banana", "pear"]


### PR DESCRIPTION
## Summary
- allow the `Deduplicate` task to run multiple times in a row, tracking each run in its own column and printing run statistics
- clarify the docstrings for `safe_json`/`safest_json` and make the API `deduplicate` wrapper default to three runs
- add a test covering multiple deduplication runs

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_i_68ae05e50f40832e947526e321dc28f6