### PR TITLE
feat: allow custom OpenAI base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ print(ratings)
 ```
 
 Each task returns a `pandas.DataFrame` and saves raw responses to disk.  Set `use_dummy=False` and provide your OpenAI credentials via the `OPENAI_API_KEY` environment variable to perform real API calls.
+If your OpenAI-compatible service uses a different endpoint, set `OPENAI_BASE_URL`
+or pass a `base_url` argument to override the default API URL.
 
 ### Image and audio inputs
 

--- a/src/gabriel/core/llm_client.py
+++ b/src/gabriel/core/llm_client.py
@@ -15,10 +15,14 @@ class LLMClient(ABC):
 class OpenAIClient(LLMClient):
     """Concrete LLM client leveraging :func:`get_response`."""
 
-    def __init__(self, api_key: Optional[str] = None) -> None:
+    def __init__(
+        self, api_key: Optional[str] = None, base_url: Optional[str] = None
+    ) -> None:
         # ``get_response`` manages a shared client; API key via env or arg
         if api_key:
             os.environ.setdefault("OPENAI_API_KEY", api_key)
+        if base_url:
+            os.environ.setdefault("OPENAI_BASE_URL", base_url)
 
     async def acall(self, messages: List[Dict[str, str]], **kwargs: Any) -> str:
         prompt = "\n".join(m.get("content", "") for m in messages)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -50,6 +50,17 @@ def test_get_response_audio_dummy():
     assert responses and responses[0].startswith("DUMMY")
 
 
+def test_custom_base_url(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    openai_utils._clients_async.clear()
+    client = openai_utils._get_client("https://example.com/v1")
+    assert str(client.base_url) == "https://example.com/v1/"
+    openai_utils._clients_async.clear()
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.org/v1")
+    client2 = openai_utils._get_client()
+    assert str(client2.base_url) == "https://example.org/v1/"
+
+
 def test_get_embedding_dummy():
     emb, _ = asyncio.run(openai_utils.get_embedding("hi", use_dummy=True))
     assert isinstance(emb, list) and emb and isinstance(emb[0], float)


### PR DESCRIPTION
## Summary
- allow overriding the OpenAI endpoint via a new `base_url` parameter or `OPENAI_BASE_URL` env var
- cache AsyncOpenAI clients per base URL for reuse
- document and test custom base URL support

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae0ad750cc832eac8bf3d151e9011d