### PR TITLE
Make safest_json LLM fix optional

### DIFF
--- a/src/gabriel/tasks/filter.py
+++ b/src/gabriel/tasks/filter.py
@@ -30,6 +30,8 @@ class FilterConfig:
     additional_instructions: str = ""
     use_dummy: bool = False
     max_timeout: Optional[float] = None
+    fix_json_with_llm: bool = False
+    json_fix_timeout: Optional[float] = 60.0
 
 
 class Filter:
@@ -113,7 +115,12 @@ class Filter:
                 run_idx = int(parts[1])
             except ValueError:
                 continue
-            parsed = await safest_json(raw)
+            parsed = await safest_json(
+                raw,
+                model=self.cfg.model if self.cfg.fix_json_with_llm else None,
+                use_llm_fallback=self.cfg.fix_json_with_llm,
+                llm_timeout=self.cfg.json_fix_timeout,
+            )
             ent_list: Optional[List[str]] = None
             if isinstance(parsed, dict):
                 val = parsed.get("entities meeting condition") or parsed.get(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -72,6 +72,11 @@ def test_safest_json_codeblock_list():
     assert parsed == {"speech": True, "music": False}
 
 
+def test_safest_json_invalid_without_fallback():
+    parsed = asyncio.run(safest_json("not json"))
+    assert parsed is None
+
+
 def test_gpt5_temperature_warning(caplog):
     """Ensure gpt-5 models ignore temperature and log a warning."""
     with caplog.at_level("WARNING"):


### PR DESCRIPTION
## Summary
- update `safest_json` so the LLM repair step is opt-in and return `None` on failure by default
- add configuration to the filter task to control whether malformed JSON should be repaired with an extra LLM call
- add a unit test covering the new default behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_i_68ae383a483c832e911e2dcd4fb9d92b