### PR TITLE
Align codify and deidentify pipeline interfaces

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -13,6 +13,7 @@ from .tasks import (
     Deidentifier,
     DeidentifyConfig,
     Codify,
+    CodifyConfig,
     Extract,
     ExtractConfig,
     Paraphrase,
@@ -177,6 +178,7 @@ async def deidentify(
     additional_guidelines: str = "",
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    reset_files: bool = False,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Deidentifier`."""
@@ -195,7 +197,12 @@ async def deidentify(
         reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
-    return await Deidentifier(cfg).run(df, column_name, grouping_column=grouping_column)
+    return await Deidentifier(cfg).run(
+        df,
+        column_name,
+        grouping_column=grouping_column,
+        reset_files=reset_files,
+    )
 
 
 async def rank(
@@ -255,7 +262,7 @@ async def codify(
     column_name: str,
     *,
     save_dir: str,
-    categories: Optional[dict[str, str]] = None,
+    categories: Optional[Dict[str, str]] = None,
     additional_instructions: str = "",
     model: str = "gpt-5-mini",
     n_parallels: int = 750,
@@ -267,27 +274,30 @@ async def codify(
     use_dummy: bool = False,
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Codify`."""
     save_dir = os.path.expandvars(os.path.expanduser(save_dir))
     os.makedirs(save_dir, exist_ok=True)
-    coder = Codify()
-    return await coder.codify(
+    cfg = CodifyConfig(
+        save_dir=save_dir,
+        file_name=file_name,
+        model=model,
+        n_parallels=n_parallels,
+        max_words_per_call=max_words_per_call,
+        max_categories_per_call=max_categories_per_call,
+        debug_print=debug_print,
+        use_dummy=use_dummy,
+        reasoning_effort=reasoning_effort,
+        reasoning_summary=reasoning_summary,
+        **cfg_kwargs,
+    )
+    return await Codify(cfg).run(
         df,
         column_name,
         categories=categories,
-        max_words_per_call=max_words_per_call,
-        max_categories_per_call=max_categories_per_call,
         additional_instructions=additional_instructions,
-        n_parallels=n_parallels,
-        model=model,
-        reasoning_effort=reasoning_effort,
-        reasoning_summary=reasoning_summary,
-        save_dir=save_dir,
-        file_name=file_name,
         reset_files=reset_files,
-        debug_print=debug_print,
-        use_dummy=use_dummy,
     )
 
 

--- a/src/gabriel/tasks/__init__.py
+++ b/src/gabriel/tasks/__init__.py
@@ -14,6 +14,7 @@ _lazy_imports = {
     "Rank": ".rank",
     "RankConfig": ".rank",
     "Codify": ".codify",
+    "CodifyConfig": ".codify",
     "Paraphrase": ".paraphrase",
     "ParaphraseConfig": ".paraphrase",
     "Extract": ".extract",

--- a/src/gabriel/tasks/discover.py
+++ b/src/gabriel/tasks/discover.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from .codify import Codify
+from .codify import Codify, CodifyConfig
 from .compare import Compare, CompareConfig
 from .bucket import Bucket, BucketConfig
 from .classify import Classify, ClassifyConfig
@@ -105,22 +105,24 @@ class Discover:
 
         # ── 1. candidate discovery ─────────────────────────────────────
         if single:
-            coder = Codify()
-            codify_df = await coder.codify(
-                df,
-                column_name,  # type: ignore[arg-type]
-                categories=None,
-                additional_instructions=self.cfg.additional_instructions or "",
+            coder_cfg = CodifyConfig(
+                save_dir=os.path.join(self.cfg.save_dir, "codify"),
+                model=self.cfg.model,
+                n_parallels=self.cfg.n_parallels,
                 max_words_per_call=self.cfg.max_words_per_call,
                 max_categories_per_call=self.cfg.max_categories_per_call,
-                n_parallels=self.cfg.n_parallels,
-                model=self.cfg.model,
-                save_dir=os.path.join(self.cfg.save_dir, "codify"),
-                reset_files=reset_files,
                 debug_print=False,
                 use_dummy=self.cfg.use_dummy,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
+            )
+            coder = Codify(coder_cfg)
+            codify_df = await coder.run(
+                df,
+                column_name,  # type: ignore[arg-type]
+                categories=None,
+                additional_instructions=self.cfg.additional_instructions or "",
+                reset_files=reset_files,
             )
             term_defs: Dict[str, str] = {}
             if "coded_passages" in codify_df:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -203,7 +203,7 @@ def test_deidentifier_dummy(tmp_path):
     cfg = DeidentifyConfig(save_dir=str(tmp_path), file_name="deid.csv", use_dummy=True)
     task = Deidentifier(cfg)
     data = pd.DataFrame({"text": ["John went to Paris."]})
-    df = asyncio.run(task.run(data, text_column="text"))
+    df = asyncio.run(task.run(data, column_name="text"))
     assert "deidentified_text" in df.columns
 
 


### PR DESCRIPTION
## Summary
- Add `CodifyConfig` and a standard `run` method so codify matches other pipelines
- Update deidentifier to accept `column_name` and `reset_files`, mirroring common run signatures
- Adjust API and discover helpers to use new codify/deidentify call patterns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae3f8b57a4832eb8d12c34f9931ac3