### PR TITLE
feat: allow custom prompt templates in pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ print(responses[0])
 ```
 
 Images are provided as base64 strings, while audio items are dictionaries with `data` and `format`. Helper functions `encode_image` and `encode_audio` are available for local files.
+### Custom prompt templates
 
+All task classes and the high-level API functions accept a `template_path`
+argument. Supply the path to a Jinja2 file that declares the same variables
+as the built-in template for that task and it will be used instead. Variable
+sets are validated before use and a helpful error is raised if a template is
+missing or introduces unexpected parameters.
 
 ## Tasks
 

--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -50,6 +50,7 @@ async def rate(
     modality: str = "text",
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rate`."""
@@ -69,7 +70,7 @@ async def rate(
         reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
-    return await Rate(cfg).run(
+    return await Rate(cfg, template_path=template_path).run(
         df,
         column_name,
         reset_files=reset_files,
@@ -92,6 +93,7 @@ async def extract(
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
     types: Optional[dict[str, any]] = None,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Extract`."""
@@ -111,7 +113,7 @@ async def extract(
         reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
-    return await Extract(cfg).run(
+    return await Extract(cfg, template_path=template_path).run(
         df,
         column_name,
         reset_files=reset_files,
@@ -135,6 +137,7 @@ async def classify(
     modality: str = "text",
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Classify`."""
@@ -155,7 +158,7 @@ async def classify(
         reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
-    return await Classify(cfg).run(
+    return await Classify(cfg, template_path=template_path).run(
         df,
         column_name,
         reset_files=reset_files,
@@ -177,6 +180,7 @@ async def deidentify(
     additional_guidelines: str = "",
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Deidentifier`."""
@@ -195,7 +199,9 @@ async def deidentify(
         reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
-    return await Deidentifier(cfg).run(df, column_name, grouping_column=grouping_column)
+    return await Deidentifier(cfg, template_path=template_path).run(
+        df, column_name, grouping_column=grouping_column
+    )
 
 
 async def rank(
@@ -219,6 +225,7 @@ async def rank(
     modality: str = "text",
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Rank`."""
@@ -243,7 +250,7 @@ async def rank(
         reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
-    return await Rank(cfg).run(
+    return await Rank(cfg, template_path=template_path).run(
         df,
         column_name,
         reset_files=reset_files,
@@ -267,11 +274,12 @@ async def codify(
     use_dummy: bool = False,
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    template_path: Optional[str] = None,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Codify`."""
     save_dir = os.path.expandvars(os.path.expanduser(save_dir))
     os.makedirs(save_dir, exist_ok=True)
-    coder = Codify()
+    coder = Codify(template_path=template_path)
     return await coder.codify(
         df,
         column_name,
@@ -312,6 +320,7 @@ async def paraphrase(
     n_initial_candidates: int = 1,
     n_validation_candidates: int = 5,
     use_modified_source: bool = False,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Paraphrase`."""
@@ -336,7 +345,7 @@ async def paraphrase(
         use_modified_source=use_modified_source,
         **cfg_kwargs,
     )
-    return await Paraphrase(cfg).run(
+    return await Paraphrase(cfg, template_path=template_path).run(
         df,
         column_name,
         reset_files=reset_files,
@@ -360,6 +369,7 @@ async def compare(
     modality: str = "text",
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Compare`."""
@@ -380,7 +390,7 @@ async def compare(
         reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
-    return await Compare(cfg).run(
+    return await Compare(cfg, template_path=template_path).run(
         df,
         circle_column_name,
         square_column_name,
@@ -403,6 +413,7 @@ async def bucket(
     differentiate: bool = False,
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Bucket`."""
@@ -422,7 +433,7 @@ async def bucket(
         reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
-    return await Bucket(cfg).run(
+    return await Bucket(cfg, template_path=template_path).run(
         df,
         column_name,
         reset_files=reset_files,
@@ -518,6 +529,7 @@ async def deduplicate(
     use_embeddings: bool = True,
     group_size: int = 500,
     max_timeout: Optional[float] = None,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Deduplicate`."""
@@ -537,7 +549,7 @@ async def deduplicate(
         group_size=group_size,
         **cfg_kwargs,
     )
-    return await Deduplicate(cfg).run(
+    return await Deduplicate(cfg, template_path=template_path).run(
         df,
         on=on,
         reset_files=reset_files,
@@ -568,6 +580,7 @@ async def merge(
     auto_match_threshold: float = 0.75,
     use_best_auto_match: bool = False,
     candidate_scan_chunks: int = 5,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Merge`."""
@@ -592,7 +605,7 @@ async def merge(
         candidate_scan_chunks=candidate_scan_chunks,
         **cfg_kwargs,
     )
-    return await Merge(cfg).run(
+    return await Merge(cfg, template_path=template_path).run(
         df_left,
         df_right,
         on=on,
@@ -621,6 +634,7 @@ async def filter(
     use_dummy: bool = False,
     file_name: str = "filter_responses.csv",
     max_timeout: Optional[float] = None,
+    template_path: Optional[str] = None,
     **cfg_kwargs,
 ) -> pd.DataFrame:
     """Convenience wrapper for :class:`gabriel.tasks.Filter`."""
@@ -643,7 +657,7 @@ async def filter(
         max_timeout=max_timeout,
         **cfg_kwargs,
     )
-    return await Filter(cfg).run(
+    return await Filter(cfg, template_path=template_path).run(
         df,
         column_name,
         reset_files=reset_files,

--- a/src/gabriel/core/prompt_template.py
+++ b/src/gabriel/core/prompt_template.py
@@ -2,8 +2,10 @@
 
 from dataclasses import dataclass
 from importlib import resources
-from jinja2 import Environment, Template, PackageLoader
-from typing import Dict
+from pathlib import Path
+from typing import Dict, Optional, Set
+
+from jinja2 import Environment, PackageLoader, meta
 
 from ..utils.jinja import shuffled, shuffled_dict
 
@@ -28,6 +30,60 @@ class PromptTemplate:
         env.filters["shuffled"] = shuffled
         template = env.from_string(self.text)
         return template.render(**params)
+
+    # ------------------------------------------------------------------
+    # Loading helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_variables(text: str) -> Set[str]:
+        """Return the set of undeclared variables in ``text``.
+
+        A minimal Jinja environment is used that registers the filters
+        expected by the built-in prompts.  This allows templates using
+        those filters to be parsed without error while ignoring their
+        actual behaviour.
+        """
+
+        env = Environment()
+        env.filters["shuffled_dict"] = lambda x: x
+        env.filters["shuffled"] = lambda x: x
+        ast = env.parse(text)
+        return meta.find_undeclared_variables(ast)
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str,
+        *,
+        reference_filename: Optional[str] = None,
+        package: str = "gabriel.prompts",
+    ) -> "PromptTemplate":
+        """Load a template from ``path`` with optional variable checking.
+
+        If ``reference_filename`` is provided, the custom template is
+        validated to ensure it declares the exact same set of variables
+        as the reference template.  A descriptive ``ValueError`` is
+        raised if there is a mismatch.
+        """
+
+        text = Path(path).read_text(encoding="utf-8")
+        if reference_filename is not None:
+            ref_text = resources.files(package).joinpath(reference_filename).read_text(
+                encoding="utf-8"
+            )
+            vars_custom = cls._extract_variables(text)
+            vars_ref = cls._extract_variables(ref_text)
+            missing = vars_ref - vars_custom
+            extra = vars_custom - vars_ref
+            if missing or extra:
+                parts = []
+                if missing:
+                    parts.append(f"missing variables: {sorted(missing)}")
+                if extra:
+                    parts.append(f"unexpected variables: {sorted(extra)}")
+                raise ValueError("Custom template variable mismatch (" + "; ".join(parts) + ")")
+        return cls(text)
 
     @classmethod
     def from_package(

--- a/src/gabriel/tasks/bucket.py
+++ b/src/gabriel/tasks/bucket.py
@@ -41,11 +41,22 @@ class BucketConfig:
 class Bucket:
     """Group raw terms into a smaller set of mutually exclusive buckets."""
 
-    def __init__(self, cfg: BucketConfig, template: Optional[PromptTemplate] = None) -> None:
+    def __init__(
+        self,
+        cfg: BucketConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
+    ) -> None:
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="bucket_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package("bucket_prompt.jinja2")
 
     async def _parse(self, raw: Any) -> Dict[str, str]:

--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -63,12 +63,21 @@ class Classify:
 
     # -----------------------------------------------------------------
     def __init__(
-        self, cfg: ClassifyConfig, template: Optional[PromptTemplate] = None
+        self,
+        cfg: ClassifyConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
     ) -> None:  # noqa: D401,E501
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="classification_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package(
             "classification_prompt.jinja2"
         )

--- a/src/gabriel/tasks/codify.py
+++ b/src/gabriel/tasks/codify.py
@@ -25,9 +25,32 @@ from ..utils import safest_json, load_image_inputs, load_audio_inputs
 class Codify:
     """Pipeline for coding passages of text according to specified categories."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
+    ) -> None:
+        """Create a new :class:`Codify` instance.
+
+        Parameters
+        ----------
+        template:
+            Optional preconstructed :class:`PromptTemplate`.
+        template_path:
+            Path to a custom Jinja2 template on disk.  The template is
+            validated to ensure it exposes the same variables as the
+            built-in ``codify_prompt.jinja2`` template.
+        """
+
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="codify_prompt.jinja2"
+            )
+        self.template = template or PromptTemplate.from_package("codify_prompt.jinja2")
         self.hit_rate_stats = {}  # Track hit rates across all texts
-        self.template = PromptTemplate.from_package("codify_prompt.jinja2")
 
     @staticmethod
     def view(

--- a/src/gabriel/tasks/compare.py
+++ b/src/gabriel/tasks/compare.py
@@ -40,12 +40,21 @@ class Compare:
     """Compare two columns row-wise using an LLM."""
 
     def __init__(
-        self, cfg: CompareConfig, template: Optional[PromptTemplate] = None
+        self,
+        cfg: CompareConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
     ) -> None:
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="comparison_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package(
             "comparison_prompt.jinja2"
         )

--- a/src/gabriel/tasks/deduplicate.py
+++ b/src/gabriel/tasks/deduplicate.py
@@ -35,11 +35,22 @@ class DeduplicateConfig:
 class Deduplicate:
     """LLM-assisted deduplication for a single DataFrame column."""
 
-    def __init__(self, cfg: DeduplicateConfig, template: Optional[PromptTemplate] = None) -> None:
+    def __init__(
+        self,
+        cfg: DeduplicateConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
+    ) -> None:
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="deduplicate_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package("deduplicate_prompt.jinja2")
 
     # ------------------------------------------------------------------

--- a/src/gabriel/tasks/deidentify.py
+++ b/src/gabriel/tasks/deidentify.py
@@ -33,8 +33,19 @@ class DeidentifyConfig:
 class Deidentifier:
     """Iterative de-identification of sensitive entities in text."""
 
-    def __init__(self, cfg: DeidentifyConfig, template: Optional[PromptTemplate] = None) -> None:
+    def __init__(
+        self,
+        cfg: DeidentifyConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
+    ) -> None:
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="deidentification_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package("deidentification_prompt.jinja2")
         os.makedirs(self.cfg.save_dir, exist_ok=True)
 

--- a/src/gabriel/tasks/extract.py
+++ b/src/gabriel/tasks/extract.py
@@ -35,11 +35,22 @@ class ExtractConfig:
 class Extract:
     """Extract attributes from passages using an LLM."""
 
-    def __init__(self, cfg: ExtractConfig, template: Optional[PromptTemplate] = None) -> None:
+    def __init__(
+        self,
+        cfg: ExtractConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
+    ) -> None:
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="extraction_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package("extraction_prompt.jinja2")
 
     async def _parse(self, raw: Any, attrs: List[str]) -> Dict[str, str]:

--- a/src/gabriel/tasks/filter.py
+++ b/src/gabriel/tasks/filter.py
@@ -37,11 +37,22 @@ class FilterConfig:
 class Filter:
     """Filter entities in a DataFrame column based on a condition using an LLM."""
 
-    def __init__(self, cfg: FilterConfig, template: Optional[PromptTemplate] = None) -> None:
+    def __init__(
+        self,
+        cfg: FilterConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
+    ) -> None:
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="filter_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package("filter_prompt.jinja2")
 
     # ------------------------------------------------------------------

--- a/src/gabriel/tasks/merge.py
+++ b/src/gabriel/tasks/merge.py
@@ -46,11 +46,22 @@ class MergeConfig:
 class Merge:
     """Fuzzy merge between two DataFrames using LLM assistance."""
 
-    def __init__(self, cfg: MergeConfig, template: Optional[PromptTemplate] = None) -> None:
+    def __init__(
+        self,
+        cfg: MergeConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
+    ) -> None:
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="merge_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package("merge_prompt.jinja2")
 
     # ------------------------------------------------------------------

--- a/src/gabriel/tasks/paraphrase.py
+++ b/src/gabriel/tasks/paraphrase.py
@@ -88,11 +88,22 @@ class ParaphraseConfig:
 class Paraphrase:
     """Paraphrase text columns in a DataFrame."""
 
-    def __init__(self, cfg: ParaphraseConfig, template: Optional[PromptTemplate] = None) -> None:
+    def __init__(
+        self,
+        cfg: ParaphraseConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
+    ) -> None:
         self.cfg = cfg
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="paraphrase_prompt.jinja2"
+            )
         # Load the paraphrasing prompt from package data if a custom
         # template is not provided.
         self.template = template or PromptTemplate.from_package("paraphrase_prompt.jinja2")

--- a/src/gabriel/tasks/rank.py
+++ b/src/gabriel/tasks/rank.py
@@ -142,7 +142,10 @@ class Rank:
     """
 
     def __init__(
-        self, cfg: RankConfig, template: Optional[PromptTemplate] = None
+        self,
+        cfg: RankConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
     ) -> None:
         """Instantiate a ranking engine.
 
@@ -154,11 +157,21 @@ class Rank:
             Optional :class:`gabriel.core.prompt_template.PromptTemplate` to
             render the comparison prompts.  If not supplied, the built‑in
             ``rankings_prompt.jinja2`` template is used.
+        template_path:
+            Path to a custom prompt template on disk. The template is
+            validated to ensure it expects the same variables as the
+            built‑in template.
         """
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="rankings_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package(
             "rankings_prompt.jinja2"
         )

--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -49,11 +49,22 @@ class Rate:
 
 
     # -----------------------------------------------------------------
-    def __init__(self, cfg: RateConfig, template: Optional[PromptTemplate] = None) -> None:
+    def __init__(
+        self,
+        cfg: RateConfig,
+        template: Optional[PromptTemplate] = None,
+        template_path: Optional[str] = None,
+    ) -> None:
         expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
         expanded.mkdir(parents=True, exist_ok=True)
         cfg.save_dir = str(expanded)
         self.cfg = cfg
+        if template is not None and template_path is not None:
+            raise ValueError("Provide either template or template_path, not both")
+        if template_path is not None:
+            template = PromptTemplate.from_file(
+                template_path, reference_filename="ratings_prompt.jinja2"
+            )
         self.template = template or PromptTemplate.from_package("ratings_prompt.jinja2")
 
     # -----------------------------------------------------------------

--- a/tests/test_custom_template.py
+++ b/tests/test_custom_template.py
@@ -1,0 +1,38 @@
+"""Tests for custom prompt template loading and validation."""
+
+from importlib import resources
+from pathlib import Path
+
+import pytest
+
+from gabriel.core.prompt_template import PromptTemplate
+
+
+def test_custom_template_matches_variables(tmp_path):
+    """A template with identical variables should load without error."""
+
+    ref = resources.files("gabriel.prompts").joinpath("ratings_prompt.jinja2").read_text(
+        encoding="utf-8"
+    )
+    custom_path = tmp_path / "custom.jinja2"
+    custom_path.write_text(ref, encoding="utf-8")
+
+    tmpl = PromptTemplate.from_file(str(custom_path), reference_filename="ratings_prompt.jinja2")
+    assert tmpl.text == ref
+
+
+def test_custom_template_variable_mismatch(tmp_path):
+    """Mismatched variables should raise a descriptive error."""
+
+    ref = resources.files("gabriel.prompts").joinpath("ratings_prompt.jinja2").read_text(
+        encoding="utf-8"
+    )
+    # Replace a known variable with an unexpected one
+    wrong = ref.replace("{{ attributes | shuffled_dict }}", "{{ wrong }}")
+    wrong_path = tmp_path / "wrong.jinja2"
+    wrong_path.write_text(wrong, encoding="utf-8")
+
+    with pytest.raises(ValueError) as excinfo:
+        PromptTemplate.from_file(str(wrong_path), reference_filename="ratings_prompt.jinja2")
+    msg = str(excinfo.value)
+    assert "missing variables" in msg or "unexpected variables" in msg


### PR DESCRIPTION
## Summary
- add `PromptTemplate.from_file` for loading custom Jinja templates with variable validation
- support optional `template_path` on all task constructors and API helpers
- document and test custom template usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ae40f62f04832e946b5bbdd616e8da