### PR TITLE
Fix codify API wrapper and confirm Colab support

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -278,7 +278,12 @@ async def codify(
     use_dummy: bool = False,
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
-
+    template_path: Optional[str] = None,
+    **cfg_kwargs,
+) -> pd.DataFrame:
+    """Convenience wrapper for :class:`gabriel.tasks.Codify`."""
+    save_dir = os.path.expandvars(os.path.expanduser(save_dir))
+    os.makedirs(save_dir, exist_ok=True)
     cfg = CodifyConfig(
         save_dir=save_dir,
         file_name=file_name,
@@ -292,7 +297,7 @@ async def codify(
         reasoning_summary=reasoning_summary,
         **cfg_kwargs,
     )
-    return await Codify(cfg).run(
+    return await Codify(cfg, template_path=template_path).run(
         df,
         column_name,
         categories=categories,


### PR DESCRIPTION
## Summary
- Repair `codify` wrapper in `api.py` after merge conflict, adding missing parameters and return annotation
- Ensure Codify configuration handles save directories and optional template path
- Verified Colab viewer option still exposed through `view_coded_passages`

## Testing
- `pytest tests/test_colab_viewer.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae46c7c2dc832e98ae31caed42f3f1