### PR TITLE
Fix predicted_classes handling and add non-text support to load_files

### DIFF
--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -20,6 +20,23 @@ from ..utils import (
 )
 
 
+def _collect_predictions(row: pd.Series) -> List[str]:
+    """Return labels whose values evaluate to ``True``.
+
+    Parameters
+    ----------
+    row:
+        A series containing only label columns.
+
+    Returns
+    -------
+    list of str
+        Labels for which the value is truthy.
+    """
+
+    return [lab for lab, val in row.items() if bool(val)]
+
+
 # ────────────────────────────
 # Configuration dataclass
 # ────────────────────────────
@@ -480,16 +497,13 @@ class Classify:
 
         label_cols = list(self.cfg.labels.keys())
 
-        def _collect_preds(row: pd.Series) -> List[str]:
-            return [lab for lab in label_cols if row.get(lab) is True]
-
         if not self.cfg.differentiate and column_name in result.columns:
             cols = result.columns.tolist()
             cols.remove(column_name)
             cols.insert(0, column_name)
             result = result[cols]
 
-        result.insert(1, "predicted_classes", result[label_cols].apply(_collect_preds, axis=1))
+        result.insert(1, "predicted_classes", result[label_cols].apply(_collect_predictions, axis=1))
 
         result_to_save = result.copy()
         result_to_save["predicted_classes"] = result_to_save["predicted_classes"].apply(json.dumps)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,11 +1,12 @@
 import asyncio
 import pandas as pd
+import numpy as np
 
 from gabriel.core.prompt_template import PromptTemplate
 from gabriel.utils import openai_utils, safest_json
 from gabriel.tasks.rate import Rate, RateConfig
 from gabriel.tasks.deidentify import Deidentifier, DeidentifyConfig
-from gabriel.tasks.classify import Classify, ClassifyConfig
+from gabriel.tasks.classify import Classify, ClassifyConfig, _collect_predictions
 from gabriel.tasks.extract import Extract, ExtractConfig
 import gabriel
 
@@ -234,6 +235,11 @@ def test_classification_multirun(tmp_path):
     assert res.predicted_classes.iloc[0] == []
     disagg = pd.read_csv(tmp_path / "classify_responses_full_disaggregated.csv", index_col=[0, 1])
     assert set(disagg.index.names) == {"text", "run"}
+
+
+def test_collect_predictions_np_bool():
+    row = pd.Series({"speech": np.bool_(True), "beeps": np.bool_(False), "space": None})
+    assert _collect_predictions(row) == ["speech"]
 
 
 def test_classify_parse_dict(tmp_path):

--- a/tests/test_load_files.py
+++ b/tests/test_load_files.py
@@ -46,3 +46,30 @@ def test_load_files_csv_direct(tmp_path):
     df = load_files(str(csv_path), save_name="copy.csv", reset_files=True)
     assert (df == df_in).all().all()
     assert os.path.exists(tmp_path / "copy.csv")
+
+
+def test_load_files_modality_paths(tmp_path):
+    base = tmp_path / "media"
+    base.mkdir()
+    (base / "a.png").write_bytes(b"img")
+    (base / "b.wav").write_bytes(b"aud")
+
+    df_img = load_files(
+        str(base),
+        extensions=["png"],
+        save_name="imgs.csv",
+        reset_files=True,
+        modality="image",
+    )
+    assert "image_path" in df_img.columns and "content" not in df_img.columns
+    assert df_img["name"].tolist() == ["a.png"]
+
+    df_aud = load_files(
+        str(base),
+        extensions=["wav"],
+        save_name="aud.csv",
+        reset_files=True,
+        modality="audio",
+    )
+    assert "audio_path" in df_aud.columns and "content" not in df_aud.columns
+    assert df_aud["name"].tolist() == ["b.wav"]


### PR DESCRIPTION
## Summary
- ensure `predicted_classes` correctly aggregates labels by evaluating truthy values
- declare `aiolimiter` as a package dependency instead of installing at runtime
- expand `load_files` with a `modality` option for image or audio paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68af6ae068b8832ea16a5acd371e6204