### PR TITLE
fix: support audio ranking with chat completions

### DIFF
--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -271,9 +271,18 @@ class Rate:
             }
             for ident_batch, raw in zip(df_resp.Identifier, df_resp.Response):
                 main = raw[0] if isinstance(raw, list) and raw else raw
-                base_ident, batch_part = ident_batch.rsplit("_batch", 1)
-                batch_idx = int(batch_part)
-                attrs = list(attr_batches[batch_idx].keys())
+                try:
+                    base_ident, batch_part = ident_batch.rsplit("_batch", 1)
+                    batch_idx = int(batch_part)
+                    attrs = list(attr_batches[batch_idx].keys())
+                except (ValueError, IndexError):
+                    if debug:
+                        print(f"[Rate] Skipping malformed identifier {ident_batch}")
+                    continue
+                if base_ident not in id_to_ratings:
+                    if debug:
+                        print(f"[Rate] Skipping unknown identifier {base_ident}")
+                    continue
                 parsed = await self._parse(main, attrs)
                 for attr in attrs:
                     id_to_ratings[base_ident][attr] = parsed.get(attr)

--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -902,11 +902,14 @@ async def get_response(
         for a in audio:
             contents.append({"type": "input_audio", "input_audio": a})
         messages = [{"role": "user", "content": contents}]
+        # ``chat.completions`` currently infers the response modality from
+        # the request content.  Supplying an explicit ``modalities`` field
+        # leads to ``Unknown parameter`` errors on newer models (e.g. gpt‑5),
+        # so we omit it here and default to text output.
         params_chat: Dict[str, Any] = {
             "model": model,
             "messages": messages,
             "temperature": temperature,
-            "modalities": ["text"],
         }
         if tools is not None:
             params_chat["tools"] = tools


### PR DESCRIPTION
## Summary
- remove unsupported `modalities` field from audio requests to OpenAI
- add regression test for audio ranking via Rank task
- skip unknown identifiers when parsing rating responses to avoid intermittent KeyErrors
- add test verifying stale identifiers in rating files are ignored

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af7e1bed3c832e9a3867d800f46870