### PR TITLE
Refine embedding concurrency and rename deduplicate column arg

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -523,7 +523,7 @@ async def discover(
 
 async def deduplicate(
     df: pd.DataFrame,
-    on: str,
+    column_name: str,
     *,
     save_dir: str,
     additional_instructions: Optional[str] = None,
@@ -558,7 +558,7 @@ async def deduplicate(
     )
     return await Deduplicate(cfg, template_path=template_path).run(
         df,
-        on=on,
+        column_name=column_name,
         reset_files=reset_files,
     )
 

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -8,7 +8,7 @@ async def _run_dedup(tmp_path, n_runs=1):
     cfg = DeduplicateConfig(save_dir=str(tmp_path), use_dummy=True, use_embeddings=False, n_runs=n_runs)
     task = Deduplicate(cfg)
     df = pd.DataFrame({"term": ["apple", "Apple", "banana", "BANANA", "pear"]})
-    return await task.run(df, on="term")
+    return await task.run(df, column_name="term")
 
 
 def test_deduplicate_dummy(tmp_path):


### PR DESCRIPTION
## Summary
- adopt more conservative rate-limit recovery for `get_all_embeddings` and default to 150 workers
- ensure `get_all_embeddings` cancels workers on interrupt
- rename deduplicate argument `on` to `column_name`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_i_68b09e88d064832eb002693c953326f3