### PR TITLE
Fix raw term injection in deduplicate prompts

### DIFF
--- a/src/gabriel/tasks/deduplicate.py
+++ b/src/gabriel/tasks/deduplicate.py
@@ -135,7 +135,7 @@ class Deduplicate:
             prompts.append(
                 self.template.render(
                     group_id=f"deduplicate_{idx:05d}",
-                    items=item_text,
+                    raw_terms=item_text,
                     additional_instructions=self.cfg.additional_instructions or "",
                 )
             )

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -1,6 +1,7 @@
 import asyncio
 import pandas as pd
 
+import gabriel.tasks.deduplicate as deduplicate
 from gabriel.tasks.deduplicate import Deduplicate, DeduplicateConfig
 
 
@@ -23,3 +24,31 @@ def test_deduplicate_multiple_runs(tmp_path):
     assert "mapped_term_final" in result.columns
     assert "mapped_term" in result.columns
     assert result["mapped_term"].tolist() == ["apple", "apple", "banana", "banana", "pear"]
+
+
+def test_prompt_contains_terms_with_embeddings(monkeypatch, tmp_path):
+    captured = {}
+
+    async def fake_get_all_responses(*, prompts, identifiers, **kwargs):
+        captured["prompts"] = prompts
+        return pd.DataFrame({"Identifier": identifiers, "Response": ["{}"] * len(identifiers)})
+
+    monkeypatch.setattr(deduplicate, "get_all_responses", fake_get_all_responses)
+
+    cfg = DeduplicateConfig(
+        save_dir=str(tmp_path),
+        use_dummy=True,
+        use_embeddings=True,
+        group_size=2,
+        n_runs=1,
+    )
+    task = Deduplicate(cfg)
+    df = pd.DataFrame({"term": ["apple", "Apple", "banana", "BANANA", "pear"]})
+    asyncio.run(task.run(df, column_name="term"))
+
+    assert "prompts" in captured
+    prompt = captured["prompts"][0]
+    assert "BEGIN RAW TERMS" in prompt
+    assert "END RAW TERMS" in prompt
+    body = prompt.split("BEGIN RAW TERMS", 1)[1].split("END RAW TERMS", 1)[0].strip()
+    assert body != ""


### PR DESCRIPTION
## Summary
- Pass `raw_terms` into deduplicate prompt template so term lists render correctly
- Add regression test ensuring prompts contain raw terms when embeddings are used

## Testing
- `python -m pytest tests/test_deduplicate.py -q`

------
https://chatgpt.com/codex/tasks/task_i_68b0a9b82360832ea54c768633438b9c