### PR TITLE
Fix recursive stage merge suffix collision

### DIFF
--- a/src/gabriel/tasks/rank.py
+++ b/src/gabriel/tasks/rank.py
@@ -1191,9 +1191,10 @@ class Rank:
                         for c in keep_cols
                         if c != "identifier"
                     }
-                    stage_dfs.append(stage_df_out.rename(columns=renamed))
+                    stage_df_clean = stage_df_out.rename(columns=renamed)
                 else:
-                    stage_dfs.append(stage_df_out.copy())
+                    stage_df_clean = stage_df_out.copy()
+                stage_dfs.append(stage_df_clean.drop(columns=["text"], errors="ignore"))
 
             _update_cumulative(stage_df_out)
 


### PR DESCRIPTION
## Summary
- drop stage-level `text` columns before merging recursive stage data
- avoid pandas suffix collisions when combining multiple stage outputs

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_i_68bb5abac530832e87304345b2dc7e26