### PR TITLE
Fix recursive rank output text column naming

### DIFF
--- a/src/gabriel/tasks/rank.py
+++ b/src/gabriel/tasks/rank.py
@@ -1226,9 +1226,12 @@ class Rank:
             {"identifier": list(exit_stage.keys()), "exit_stage": list(exit_stage.values())}
         )
 
-        final_cols = [c for c in final_stage_df.columns if c != "text"]
+        final_cols = [c for c in final_stage_df.columns if c != "identifier"]
         final_raw = final_stage_df.rename(
-            columns={c: (c if c == "identifier" else f"final_{c}") for c in final_cols}
+            columns={
+                c: ("final_text" if c == "text" else f"final_{c}")
+                for c in final_cols
+            }
         )
 
         latest_text_df = work_df[["identifier", "text"]].copy()


### PR DESCRIPTION
## Summary
- rename the final stage text column to `final_text` when assembling recursive ranking outputs
- avoid column collisions when combining cumulative, exit, text, and final stage data

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_i_68bb5c8db298832ea5dcea47b8070a3c